### PR TITLE
Update all NuGet References (2.1.0 to 2.1.1)

### DIFF
--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
+    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
   </ItemGroup>
 

--- a/src/BaGet.Tools.AzureSearchImporter/BaGet.Tools.AzureSearchImporter.csproj
+++ b/src/BaGet.Tools.AzureSearchImporter/BaGet.Tools.AzureSearchImporter.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
-    <PackageReference Include="morelinq" Version="2.10.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="morelinq" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Tools.ImportDownloads/BaGet.Tools.ImportDownloads.csproj
+++ b/src/BaGet.Tools.ImportDownloads/BaGet.Tools.ImportDownloads.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Update all NuGet References to the newest/current Version (NO Pre-Release Versions)

Basically update from 2.1.0 to 2.1.1

Without this i had a few error messages during "dotnet build" .
Using dotnet-sdk-2.1.301-windows-x64 inside VS 2017 (15.7.4 Release) build.

With this prerequisitex xUnit Packages can be installed/configured as next.

Verified: 
- all the Console Apps are targeting ".NET Core 2.1"
- all the Assemblies are targeting ".NET Standard 2.0"