### PR TITLE
Issue with lowercase on *nix platforms is fixed

### DIFF
--- a/src/BaGet.Core/Services/FilePackageStorageService.cs
+++ b/src/BaGet.Core/Services/FilePackageStorageService.cs
@@ -68,8 +68,8 @@ namespace BaGet.Core.Services
 
         private void EnsurePathExists(PackageIdentity package)
         {
-            var id = package.Id;
-            var version = package.Version.ToNormalizedString();
+            var id = package.Id.ToLowerInvariant();
+            var version = package.Version.ToNormalizedString().ToLowerInvariant();
             var path = Path.Combine(_storePath, id, version);
 
             Directory.CreateDirectory(path);


### PR DESCRIPTION
### What does this PR do?

Fixes issue with crash of SavePackageStreamAsync on Linux. 
Issue was in EnsurePathExists which doesn't lowercase package related path parts.

### Closes Issue(s)

None

### Motivation

Since this project is dotnet core it would be nice to have it up and running on *nix platforms.

### Additional Notes

TODO: Consider to move to dedicated method in extension:
```
            var id = package.Id.ToLowerInvariant();
            var version = package.Version.ToNormalizedString().ToLowerInvariant();
```