### PR TITLE
Docker build script and descriptions are added

### DIFF
--- a/baget-nuget-server.env
+++ b/baget-nuget-server.env
@@ -1,0 +1,7 @@
+ASPNETCORE_ENVIRONMENT=Development
+ApiKeyHash=658489D79E218D2474D049E8729198D86DB0A4AF43981686A31C7DCB02DC0900
+Storage__Type=FileSystem
+Storage__Path=/nuget-data/packages
+Database__Type=Sqlite
+Database__ConnectionString=Data Source=/nuget-data/baget.db
+Search__Type=Database

--- a/docker-readme.md
+++ b/docker-readme.md
@@ -1,0 +1,27 @@
+# Build docker:
+
+```
+docker build . -t baget-nuget-server
+```
+
+# Run docker container:
+
+Create file with environments or pass environment variables through command line via -e VAR=VALUE.
+
+```baget-nuget-server.env
+ASPNETCORE_ENVIRONMENT=Development
+ApiKeyHash=<NUGET-SERVER-API-KEY>
+Storage__Type=FileSystem
+Storage__Path=/nuget-data/packages
+Database__Type=Sqlite
+Database__ConnectionString=Data Source=/nuget-data/baget.db
+Search__Type=Database
+```
+
+```
+docker run --name nuget-server -p 5555:80 --env-file baget-nuget-server.env -v c:/nuget-data:/nuget-data baget-nuget-server:latest
+```
+
+TODO:
+- Replace port 5555 with appropriate one.
+- Replace "c:/nuget-data" with appropriate path for desired environment and OS.

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,19 @@
+FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM microsoft/dotnet:2.1-sdk AS build
+WORKDIR /src
+COPY . /src
+WORKDIR /src
+RUN dotnet restore src/BaGet
+RUN dotnet build src/BaGet -c Debug -o /app
+
+FROM build AS publish
+RUN dotnet publish src/BaGet -c Debug -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+
+ENTRYPOINT ["dotnet", "BaGet.dll"]


### PR DESCRIPTION
### What does this PR do?

Dockerfile contains parts to build and run BaGet in container environment.
docker-readme.md describes how to build and run container.
baget-nuget-server.env - sample set of environment variables. This list is not complete yet. 

"658489D79E218D2474D049E8729198D86DB0A4AF43981686A31C7DCB02DC0900"
is SHA256 for:
"NUGET-SERVER-API-KEY"
so that you can use it during publish nuget to server.

### Closes Issue(s)

Closes [https://github.com/loic-sharma/BaGet/issues/37](url)



### Motivation


### Additional Notes

