### PR TITLE
write file to disk if it doesn't exist

### DIFF
--- a/src/BaGet.Azure/BlobPackageStorageService.cs
+++ b/src/BaGet.Azure/BlobPackageStorageService.cs
@@ -23,6 +23,11 @@ namespace BaGet.Azure.Configuration
             _container = container ?? throw new ArgumentNullException(nameof(container));
         }
 
+        public Task<bool> ExistsAsync(PackageIdentity package)
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task DeleteAsync(PackageIdentity package)
         {
             await GetPackageBlob(package).DeleteIfExistsAsync();
@@ -36,6 +41,7 @@ namespace BaGet.Azure.Configuration
 
             return DownloadBlobAsync(blob);
         }
+
         public Task<Stream> GetNuspecStreamAsync(PackageIdentity package)
         {
             var blob = GetNuspecBlob(package);

--- a/src/BaGet.Core/Services/FilePackageStorageService.cs
+++ b/src/BaGet.Core/Services/FilePackageStorageService.cs
@@ -49,10 +49,17 @@ namespace BaGet.Core.Services
         public Task<Stream> GetPackageStreamAsync(PackageIdentity package) => Task.FromResult(GetPackageStream(package));
         public Task<Stream> GetNuspecStreamAsync(PackageIdentity package) => Task.FromResult(GetNuspecStream(package));
         public Task<Stream> GetReadmeStreamAsync(PackageIdentity package) => Task.FromResult(GetReadmeStream(package));
+        public Task<bool> ExistsAsync(PackageIdentity package) => Task.FromResult(CheckIfFileExists(package.PackagePath()));
 
         private Stream GetPackageStream(PackageIdentity package) => GetFileStream(package.PackagePath());
         private Stream GetNuspecStream(PackageIdentity package) => GetFileStream(package.NuspecPath());
         private Stream GetReadmeStream(PackageIdentity package) => GetFileStream(package.ReadmePath());
+
+        private bool CheckIfFileExists(string path)
+        {
+            path = Path.Combine(_storePath, path);
+            return File.Exists(path);
+        }
 
         private Stream GetFileStream(string path)
         {
@@ -70,7 +77,7 @@ namespace BaGet.Core.Services
         {
             var id = package.Id.ToLowerInvariant();
             var version = package.Version.ToNormalizedString().ToLowerInvariant();
-            var path = Path.Combine(_storePath, id, version);
+            var path = Path.Combine(_storePath, id, version).ToLowerInvariant();
 
             Directory.CreateDirectory(path);
         }

--- a/src/BaGet.Core/Services/IPackageStorageService.cs
+++ b/src/BaGet.Core/Services/IPackageStorageService.cs
@@ -13,6 +13,7 @@ namespace BaGet.Core.Services
         Task<Stream> GetPackageStreamAsync(PackageIdentity package);
         Task<Stream> GetNuspecStreamAsync(PackageIdentity package);
         Task<Stream> GetReadmeStreamAsync(PackageIdentity package);
+        Task<bool> ExistsAsync(PackageIdentity package);
 
         Task DeleteAsync(PackageIdentity package);
     }

--- a/src/BaGet.Core/Services/IndexingService.cs
+++ b/src/BaGet.Core/Services/IndexingService.cs
@@ -48,7 +48,7 @@ namespace BaGet.Core.Services
 
                     var identity = new PackageIdentity(packageId, packageVersion);
 
-                    if (await _storage.ExistsAsync(identity))
+                    if (await _storage.ExistsAsync(identity) && await _packages.ExistsAsync(packageId, packageVersion))
                     {
                         return IndexingResult.PackageAlreadyExists;
                     }


### PR DESCRIPTION
### What does this PR do?

If a file is in the db, but not on disk, currently registration fails with 409, without updating file on disk. This PR re-saves file to disk (if for instance, it was deleted or not persisted)

### Motivation

As I was setting it up to host our internal nuget packages, I kept running conflict issues when my files weren't even there. My motivation was to harden the implementation a little bit, without changing any of the client expectations (it will still return a 409, for instance) 