### PR TITLE
add allowed forwarded headers so it can work behind proxy

### DIFF
--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -10,6 +10,7 @@ using BaGet.Extensions;
 using BaGet.Web.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +45,14 @@ namespace BaGet
                     builder => builder.AllowAnyOrigin()
                         .AllowAnyMethod()
                         .AllowAnyHeader());
+            });
+            
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                // Do not restrict to local network/proxy
+                options.KnownNetworks.Clear();
+                options.KnownProxies.Clear();
             });
 
             services.AddSingleton<IAuthenticationService, ApiKeyAuthenticationService>(provider =>
@@ -124,6 +133,7 @@ namespace BaGet
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseForwardedHeaders();
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
### What does this PR do?

Allows BaGet to work behind an https proxy

### Closes Issue(s)
none

### Motivation

We have ssl termination at our proxy, with BaGet running behind it over http. Before the urls were all wrong (with `http` protocol), after this, they're all correct

### Additional Notes

I decided to let aspnet trust all proxies, but in the future it should probably be configurable. 