### PR TITLE
Fixes for Issue #76

### DIFF
--- a/src/BaGet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaGet/Extensions/ServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace BaGet.Extensions
 
         public static IServiceCollection ConfigureHttpServices(this IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc().AddApplicationPart(typeof(BaGet.Web.Routes).Assembly);
             services.AddCors();
             services.AddSingleton<IConfigureOptions<CorsOptions>, ConfigureCorsOptions>();
 

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -32,18 +32,17 @@ namespace BaGet
             {
                 app.UseDeveloperExceptionPage();
                 app.UseStatusCodePages();
+            }
 
-                // Run migrations automatically in development mode.
-                var scopeFactory = app.ApplicationServices
-                    .GetRequiredService<IServiceScopeFactory>();
+            var scopeFactory = app.ApplicationServices
+                .GetRequiredService<IServiceScopeFactory>();
 
-                using (var scope = scopeFactory.CreateScope())
-                {
-                    scope.ServiceProvider
-                        .GetRequiredService<IContext>()
-                        .Database
-                        .Migrate();
-                }
+            using (var scope = scopeFactory.CreateScope())
+            {
+                scope.ServiceProvider
+                    .GetRequiredService<IContext>()
+                    .Database
+                    .Migrate();
             }
 
             app.UseForwardedHeaders();

--- a/tests/BaGet.Tests/SearchControllerTest.cs
+++ b/tests/BaGet.Tests/SearchControllerTest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using Xunit.Abstractions;
+namespace BaGet.Tests
+{
+    public class SearchControllerTest
+    {
+        protected readonly ITestOutputHelper Helper;
+
+        readonly string EntryUrl = "/v3/search"; 
+
+        public SearchControllerTest(ITestOutputHelper helper)
+        {
+            Helper = helper ?? throw new ArgumentNullException(nameof(helper));
+        }
+
+        [Fact]
+        public async Task AskEmptyServer()
+        {
+            using (TestServer server = TestServerBuilder.Create().Build())
+            {
+                var response = await server.CreateClient().GetAsync(EntryUrl);
+                Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+    }
+}

--- a/tests/BaGet.Tests/TestServerBuilder.cs
+++ b/tests/BaGet.Tests/TestServerBuilder.cs
@@ -26,6 +26,8 @@ namespace BaGet.Tests
         private readonly string ConnectionStringKey = $"{nameof(BaGetOptions.Database)}:{nameof(DatabaseOptions.ConnectionString)}";
         private readonly string StorageTypeKey = $"{nameof(BaGetOptions.Storage)}:{nameof(StorageOptions.Type)}";
         private readonly string FileSystemStoragePathKey = $"{nameof(BaGetOptions.Storage)}:{nameof(FileSystemStorageOptions.Path)}";
+        private readonly string SearchTypeKey = $"{nameof(BaGetOptions.Search)}:{nameof(SearchOptions.Type)}";
+        private readonly string MirrorEnabledKey = $"{nameof(BaGetOptions.Mirror)}:{nameof(MirrorOptions.Enabled)}";
 
         private ITestOutputHelper _helper;
         private LogLevel _minimumLevel = LogLevel.None;
@@ -83,6 +85,8 @@ namespace BaGet.Tests
             Configuration.Add(ConnectionStringKey, string.Format("Data Source={0}", resolvedSqliteFile));
             Configuration.Add(StorageTypeKey, StorageType.FileSystem.ToString());
             Configuration.Add(FileSystemStoragePathKey, storageFolderPath);
+            Configuration.Add(SearchTypeKey, nameof(SearchType.Database));
+            Configuration.Add(MirrorEnabledKey, false.ToString());
             return this;
         }
 
@@ -103,16 +107,6 @@ namespace BaGet.Tests
             }
 
             TestServer server = new TestServer(hostBuilder);
-
-            //Ensure that the Database is created, we use the same feature like inside the Startup in case of Env.IsDevelopment (EF-Migrations)
-            var scopeFactory = server.Host.Services.GetRequiredService<IServiceScopeFactory>();
-            using (var scope = scopeFactory.CreateScope())
-            {
-                scope.ServiceProvider
-                    .GetRequiredService<IContext>()
-                    .Database
-                    .Migrate();
-            }
             return server;
         }
     }


### PR DESCRIPTION
### What does this PR do?

- call .Migrate on each start
- create test for this usecase
- fix test ennvironment for false positive results


### Closes Issue(s)
#76 

### Additional Notes
Reading EF-Documentation we can assume that .Migrate is idempotent!
.Migrate() is called on every start now (only for development in the past)

premature optimization: 
yes startup may be slower doing Migrate every time
- we should measure before we change
- idea: a flag "--suppress-migration" on the commandline may solve that for DevOps



