### PR TITLE
WIP fix/implement caching upstream #93

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/BaGet/bin/Debug/netcoreapp2.0/BaGet.dll",
+            "program": "${workspaceFolder}/src/BaGet/bin/Debug/netcoreapp2.1/BaGet.dll",
             "args": [],
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/src/BaGet",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart",
             "launchBrowser": {

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
-    <PackageReference Include="NuGet.Packaging" Version="4.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="4.8.0" />
+    <PackageReference Include="NuGet.Protocol" Version="4.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BaGet.Core/Mirror/FakeMirrorService.cs
+++ b/src/BaGet.Core/Mirror/FakeMirrorService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace BaGet.Core.Mirror
@@ -9,6 +11,19 @@ namespace BaGet.Core.Mirror
     /// </summary>
     public class FakeMirrorService : IMirrorService
     {
+        Task<IReadOnlyList<string>> emptyVersions = Task.Factory.StartNew(() => new List<string>() as IReadOnlyList<string>);
+        Task<IEnumerable<IPackageSearchMetadata>> emptyMeta = Task.Factory.StartNew(() => new List<IPackageSearchMetadata>() as IEnumerable<IPackageSearchMetadata>);
+
+        public Task<IReadOnlyList<string>> FindUpstreamAsync(string id, CancellationToken ct)
+        {
+            return emptyVersions;
+        }
+
+        public Task<IEnumerable<IPackageSearchMetadata>> FindUpstreamMetadataAsync(string id, CancellationToken ct)
+        {
+            return emptyMeta;
+        }
+
         public Task MirrorAsync(
             string id,
             NuGetVersion version,

--- a/src/BaGet.Core/Mirror/IMirrorService.cs
+++ b/src/BaGet.Core/Mirror/IMirrorService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace BaGet.Core.Mirror
@@ -17,5 +19,9 @@ namespace BaGet.Core.Mirror
         /// <param name="cancellationToken">The token to cancel the mirroring</param>
         /// <returns>A task that completes when the package has been mirrored.</returns>
         Task MirrorAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
+
+        Task<IReadOnlyList<string>> FindUpstreamAsync(string id, CancellationToken ct);
+
+        Task<IEnumerable<IPackageSearchMetadata>> FindUpstreamMetadataAsync(string id, CancellationToken ct);
     }
 }

--- a/src/BaGet.Core/Mirror/MirrorService.cs
+++ b/src/BaGet.Core/Mirror/MirrorService.cs
@@ -1,9 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGet.Core.Services;
 using Microsoft.Extensions.Logging;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGet.Protocol;
+using NuGet.Common;
+using System.Linq;
 
 namespace BaGet.Core.Mirror
 {
@@ -14,6 +20,11 @@ namespace BaGet.Core.Mirror
         private readonly IPackageDownloader _downloader;
         private readonly IIndexingService _indexer;
         private readonly ILogger<MirrorService> _logger;
+        private readonly SourceRepository _sourceRepository;
+        private SourceCacheContext _cacheContext;
+        NuGetLoggerAdapter<MirrorService> _loggerAdapter;
+        private PackageMetadataResourceV3 _metadataSearch;
+        private RemoteV3FindPackageByIdResource _versionSearch;
 
         public MirrorService(
             Uri packageBaseAddress,
@@ -27,6 +38,28 @@ namespace BaGet.Core.Mirror
             _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
             _indexer = indexer ?? throw new ArgumentNullException(nameof(indexer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this._loggerAdapter = new NuGetLoggerAdapter<MirrorService>(_logger);
+            List<Lazy<INuGetResourceProvider>> providers = new List<Lazy<INuGetResourceProvider>>();
+            providers.AddRange(Repository.Provider.GetCoreV3());
+            providers.Add(new Lazy<INuGetResourceProvider>(() => new PackageMetadataResourceV3Provider()));
+            PackageSource packageSource = new PackageSource("https://api.nuget.org/v3/index.json"); //TODO needs options
+            _sourceRepository = new SourceRepository(packageSource, providers);
+            _cacheContext = new SourceCacheContext();
+            var httpSource = _sourceRepository.GetResource<HttpSourceResource>();
+            RegistrationResourceV3 regResource = _sourceRepository.GetResource<RegistrationResourceV3>();
+            ReportAbuseResourceV3 reportAbuseResource = _sourceRepository.GetResource<ReportAbuseResourceV3>();
+            _metadataSearch = new PackageMetadataResourceV3(httpSource.HttpSource, regResource, reportAbuseResource);
+            _versionSearch = new RemoteV3FindPackageByIdResource(_sourceRepository, httpSource.HttpSource);
+        }
+
+        public async Task<IEnumerable<IPackageSearchMetadata>> FindUpstreamMetadataAsync(string id, CancellationToken ct) {
+            return await _metadataSearch.GetMetadataAsync(id, true, false, _cacheContext, _loggerAdapter, ct);
+        }
+
+        public async Task<IReadOnlyList<string>> FindUpstreamAsync(string id, CancellationToken ct)
+        {           
+            var versions = await _versionSearch.GetAllVersionsAsync(id, _cacheContext, _loggerAdapter, ct);
+            return versions.Select(v => v.ToNormalizedString()).ToList();
         }
 
         public async Task MirrorAsync(string id, NuGetVersion version, CancellationToken cancellationToken)

--- a/src/BaGet.Core/NuGetLoggerAdapter.cs
+++ b/src/BaGet.Core/NuGetLoggerAdapter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace BaGet.Core
+{
+    public class NuGetLoggerAdapter<T> : NuGet.Common.ILogger
+    {
+        Microsoft.Extensions.Logging.ILogger<T> logger;
+
+        public NuGetLoggerAdapter(Microsoft.Extensions.Logging.ILogger<T> logger) {
+            this.logger = logger ?? throw new ArgumentNullException("logger");
+        }
+
+
+        public void Log(NuGet.Common.LogLevel level, string data)
+        {
+            switch(level) {
+                case NuGet.Common.LogLevel.Error:
+                    this.logger.LogError(data);
+                    break;
+                case NuGet.Common.LogLevel.Debug:
+                    this.logger.LogDebug(data);
+                    break;
+                case NuGet.Common.LogLevel.Minimal:
+                    this.logger.LogDebug(data);
+                    break;
+                case NuGet.Common.LogLevel.Information:
+                    this.logger.LogInformation(data);
+                    break;
+                case NuGet.Common.LogLevel.Verbose:
+                    this.logger.LogTrace(data);
+                    break;
+                case NuGet.Common.LogLevel.Warning:
+                    this.logger.LogWarning(data);
+                    break;
+            }            
+        }
+
+        public void Log(NuGet.Common.ILogMessage message)
+        {
+            this.Log(message.Level, message.Message);
+        }
+
+        public Task LogAsync(NuGet.Common.LogLevel level, string data)
+        {
+            this.Log(level, data);
+            return Task.CompletedTask;
+        }
+
+        public Task LogAsync(NuGet.Common.ILogMessage message)
+        {
+            this.Log(message.Level, message.Message);
+            return Task.CompletedTask;
+        }
+
+        public void LogDebug(string data)
+        {
+            this.logger.LogDebug(data);
+        }
+
+        public void LogError(string data)
+        {
+            this.logger.LogError(data);
+        }
+
+        public void LogInformation(string data)
+        {
+            this.logger.LogInformation(data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            this.logger.LogInformation(data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            this.logger.LogDebug(data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            this.logger.LogDebug(data);
+        }
+
+        public void LogWarning(string data)
+        {
+            this.logger.LogWarning(data);
+        }
+    }
+}

--- a/src/BaGet.Web/Controllers/PackageController.cs
+++ b/src/BaGet.Web/Controllers/PackageController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +30,13 @@ namespace BaGet.Controllers
 
             if (!packages.Any())
             {
+                IReadOnlyList<string> upstreamVersions = await _mirror.FindUpstreamAsync(id, CancellationToken.None);
+                if(upstreamVersions.Any()) {
+                    return Json(new
+                    {
+                        Versions = upstreamVersions.ToList()
+                    });
+                }
                 return NotFound();
             }
 


### PR DESCRIPTION
For read-through caching, queries to registration and package service
must be directed to upstream server. Otherwise client would get always
404 because there is nothing in the cache to begin with.
We can add caching queries too, but that requires integrating catalog
reader to refresh responses for already cached packages.


### What does this PR do?

Fixes read-through cache.

### Closes Issue(s)

#93

### Additional Notes

 * still need to add an option to parametrrize cache source. I don't think previous option was ever sufficient `"PackageSource": "https://api.nuget.org/v3-flatcontainer/"`. I think we need to specify full URL to the index of nuget server. Such as `"https://api.nuget.org/v3/index.json"`.
 * this is working now, but there are 3 endpoints which work by checking local packages first and then fallback to ask nuget.org. I think it would be more sensible if caching endpoint was separate from private index. Please tell me if I can move it.
 * I'll add unit tests before merge.