### PR TITLE
Fix index versions and urls; add tests

### DIFF
--- a/src/BaGet.Web/Controllers/IndexController.cs
+++ b/src/BaGet.Web/Controllers/IndexController.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using BaGet.Web.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
@@ -10,31 +12,31 @@ namespace BaGet.Web.Controllers
     /// </summary>
     public class IndexController : Controller
     {
+        private IEnumerable<ServiceResource> ServiceWithAliases(string name, string url, params string[] versions) 
+        {
+            foreach (var version in versions) 
+            {
+                string fullname = string.IsNullOrEmpty(version) ? name : name + "/" + version;
+                yield return new ServiceResource(fullname, url);
+            }
+        }
+
         // GET v3/index
         [HttpGet]
         public object Get()
         {
             // Documentation: https://docs.microsoft.com/en-us/nuget/api/overview
-            // NuGet.org: https://api.nuget.org/v3-index/index.json
-
-            // TODO: Client is picky about versions' formatting. Needs more research. See:
-            // https://github.com/NuGet/NuGet.Client/blob/67d34ee8158597377fb26e06987ad6ad40a1b09b/src/NuGet.Core/NuGet.Protocol/Constants.cs
+            // NuGet.org: https://api.nuget.org/v3-index/index.json            
             return new
             {
-                Version = "3.0.0-beta.1",
-                Resources = new[]
-                {
-                    // Required
-                    new ServiceResource("PackagePublish/Versioned", Url.PackagePublish()),
-                    new ServiceResource("SearchQueryService/Versioned", Url.PackageSearch()),
-                    new ServiceResource("RegistrationsBaseUrl/Versioned", Url.RegistrationsBase()),
-                    new ServiceResource("PackageBaseAddress/Versioned", Url.PackageBase()),
-
-                    // Optional
-                    new ServiceResource("SearchAutocompleteService/Versioned", Url.PackageAutocomplete()),
-                    //new ServiceResource("ReportAbuseUriTemplate/3.0.0-rc", new Uri("https://google.com")),
-                    //new ServiceResource("Catalog/3.0.0", new Uri("https://google.com"))
-                }
+                Version = "3.0.0",
+                Resources = 
+                    ServiceWithAliases("PackagePublish", Url.PackagePublish(), "2.0.0") // api.nuget.org returns this too.
+                    .Concat(ServiceWithAliases("SearchQueryService", Url.PackageSearch(), "", "3.0.0-beta", "3.0.0-rc")) // each version is an alias of others
+                    .Concat(ServiceWithAliases("RegistrationsBaseUrl", Url.RegistrationsBase(), "", "3.0.0-rc", "3.0.0-beta"))
+                    .Concat(ServiceWithAliases("PackageBaseAddress", Url.PackageBase(), "3.0.0"))
+                    .Concat(ServiceWithAliases("SearchAutocompleteService", Url.PackageAutocomplete(), "", "3.0.0-rc", "3.0.0-beta"))
+                    .ToList()
             };
         }
 

--- a/src/BaGet.Web/Extensions/UrlExtensions.cs
+++ b/src/BaGet.Web/Extensions/UrlExtensions.cs
@@ -6,8 +6,8 @@ namespace BaGet.Web.Extensions
 {
     public static class UrlExtensions
     {
-        public static string PackageBase(this IUrlHelper url) => url.AbsoluteUrl("v3/package");
-        public static string RegistrationsBase(this IUrlHelper url) => url.AbsoluteUrl("v3/registration");
+        public static string PackageBase(this IUrlHelper url) => url.AbsoluteUrl("v3/package/");
+        public static string RegistrationsBase(this IUrlHelper url) => url.AbsoluteUrl("v3/registration/");
         public static string PackagePublish(this IUrlHelper url) => url.AbsoluteRouteUrl(Routes.UploadRouteName);
         public static string PackageSearch(this IUrlHelper url) => url.AbsoluteRouteUrl(Routes.SearchRouteName);
         public static string PackageAutocomplete(this IUrlHelper url) => url.AbsoluteRouteUrl(Routes.AutocompleteRouteName);

--- a/src/BaGet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaGet/Extensions/ServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace BaGet.Extensions
 
         public static IServiceCollection ConfigureHttpServices(this IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc().AddApplicationPart(typeof(BaGet.Web.Routes).Assembly);
             services.AddCors();
             services.AddSingleton<IConfigureOptions<CorsOptions>, ConfigureCorsOptions>();
 

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NuGet.Protocol" Version="4.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/tests/BaGet.Tests/NuGetClientIntegrationTest.cs
+++ b/tests/BaGet.Tests/NuGetClientIntegrationTest.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using Xunit.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol;
+using NuGet.Configuration;
+using BaGet.Tests.Support;
+using System.Net.Http;
+using System.Net;
+
+namespace BaGet.Tests
+{
+    /// <summary>
+    /// Uses official nuget client packages to talk to test host.
+    /// </summary>
+    public class NuGetClientIntegrationTest : IDisposable
+    {
+        protected readonly ITestOutputHelper Helper;
+        private readonly TestServer server;
+        readonly string IndexUrlString = "v3/index.json";
+        SourceRepository _sourceRepository;
+        private SourceCacheContext _cacheContext;
+        HttpSourceResource _httpSource;
+        private HttpClient _httpClient;
+        string indexUrl;
+
+        public NuGetClientIntegrationTest(ITestOutputHelper helper)
+        {
+            Helper = helper ?? throw new ArgumentNullException(nameof(helper));
+            server = TestServerBuilder.Create().TraceToTestOutputHelper(Helper,LogLevel.Error).Build();
+            var providers = new List<Lazy<INuGetResourceProvider>>();
+            providers.AddRange(Repository.Provider.GetCoreV3());
+            providers.Add(new Lazy<INuGetResourceProvider>(() => new PackageMetadataResourceV3Provider()));
+            _httpClient = server.CreateClient();
+            providers.Insert(0, new Lazy<INuGetResourceProvider>(() => new HttpSourceResourceProviderTestHost(_httpClient)));
+
+            indexUrl = new Uri(server.BaseAddress, IndexUrlString).AbsoluteUri;
+            PackageSource packageSource = new PackageSource(indexUrl); 
+            _sourceRepository = new SourceRepository(packageSource, providers);
+            _cacheContext = new SourceCacheContext() { NoCache = true, MaxAge=new DateTimeOffset(), DirectDownload=true };
+            _httpSource = _sourceRepository.GetResource<HttpSourceResource>();
+            Assert.IsType<HttpSourceTestHost>(_httpSource.HttpSource);
+        }
+        public void Dispose()
+        {
+            if(server != null)
+                server.Dispose();
+        }
+
+        [Fact]
+        public async Task GetIndexShouldReturn200()
+        {
+            var index = await _httpClient.GetAsync(indexUrl);
+            Assert.Equal(HttpStatusCode.OK, index.StatusCode);
+            return;
+        }
+
+        [Fact]
+        public async Task IndexResourceHasManyEntries()
+        {
+            var indexResource = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            Assert.NotEmpty(indexResource.Entries);
+        }
+
+        [Fact]
+        public async Task IndexIncludesAtLeastOneSearchQueryEntry()
+        {
+            var indexResource = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            Assert.NotEmpty(indexResource.GetServiceEntries("SearchQueryService"));
+        }
+
+        [Fact]
+        public async Task IndexIncludesAtLeastOneRegistrationsBaseEntry()
+        {
+            var indexResource = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            Assert.NotEmpty(indexResource.GetServiceEntries("RegistrationsBaseUrl"));
+        }
+
+        [Fact]
+        public async Task IndexIncludesAtLeastOnePackageBaseAddressEntry()
+        {
+            var indexResource = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            Assert.NotEmpty(indexResource.GetServiceEntries("PackageBaseAddress/3.0.0"));
+        }
+
+        [Fact]
+        public async Task IndexIncludesAtLeastOneSearchAutocompleteServiceEntry()
+        {
+            var indexResource = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            Assert.NotEmpty(indexResource.GetServiceEntries("SearchAutocompleteService"));
+        }
+
+    }
+}

--- a/tests/BaGet.Tests/Support/HttpSourceResourceProviderTestHost.cs
+++ b/tests/BaGet.Tests/Support/HttpSourceResourceProviderTestHost.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace BaGet.Tests.Support
+{
+    /// <summary>
+    /// Similar to official HttpSourceResourceProvider, but uses test host.
+    /// </summary>
+    public class HttpSourceResourceProviderTestHost : ResourceProvider
+    {
+        // Only one HttpSource per source should exist. This is to reduce the number of TCP connections.
+        private readonly ConcurrentDictionary<PackageSource, HttpSourceResource> _cache
+            = new ConcurrentDictionary<PackageSource, HttpSourceResource>();
+        private HttpClient _httpClient;
+
+        /// <summary>
+        /// The throttle to apply to all <see cref="HttpSource"/> HTTP requests.
+        /// </summary>
+        public static IThrottle Throttle { get; set; }
+
+        public HttpSourceResourceProviderTestHost(HttpClient client)
+            : base(typeof(HttpSourceResource),
+                  nameof(HttpSourceResource),
+                  NuGetResourceProviderPositions.Last)
+        {
+            this._httpClient = client;
+        }
+
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            Debug.Assert(source.PackageSource.IsHttp, "HTTP source requested for a non-http source.");
+
+            HttpSourceResource curResource = null;
+
+            if (source.PackageSource.IsHttp)
+            {
+                curResource = _cache.GetOrAdd(
+                    source.PackageSource, 
+                    packageSource => new HttpSourceResource(HttpSourceTestHost.Create(source, _httpClient)));
+            }
+
+            return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
+        }
+    }
+}

--- a/tests/BaGet.Tests/Support/HttpSourceTestHost.cs
+++ b/tests/BaGet.Tests/Support/HttpSourceTestHost.cs
@@ -1,0 +1,47 @@
+namespace BaGet.Tests.Support
+{
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using System.Reflection;
+
+public class HttpSourceTestHost : HttpSource {
+    public static HttpSourceTestHost Create(SourceRepository source, HttpClient client)
+    {
+        Func<Task<HttpHandlerResource>> factory = () => source.GetResourceAsync<HttpHandlerResource>();
+
+        return new HttpSourceTestHost(source.PackageSource, factory, NullThrottle.Instance, client);
+    }
+    public HttpSourceTestHost(
+        PackageSource packageSource,
+        Func<Task<HttpHandlerResource>> messageHandlerFactory,
+        IThrottle throttle,
+        HttpClient client) 
+        :base(packageSource, messageHandlerFactory, throttle)
+        {
+            var prop = typeof(HttpSource).GetField("_httpClient", 
+                System.Reflection.BindingFlags.NonPublic  | System.Reflection.BindingFlags.Instance);
+            prop.SetValue(this, client);
+            this.HttpCacheDirectory = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+            var cacheDir = new DirectoryInfo(this.HttpCacheDirectory);
+            if(cacheDir.Exists) {
+                foreach(var dir in cacheDir.EnumerateDirectories()) {
+                    dir.Delete(true);
+                }
+            }
+        }
+    }
+}

--- a/tests/BaGet.Tests/TestServerBuilder.cs
+++ b/tests/BaGet.Tests/TestServerBuilder.cs
@@ -26,6 +26,8 @@ namespace BaGet.Tests
         private readonly string ConnectionStringKey = $"{nameof(BaGetOptions.Database)}:{nameof(DatabaseOptions.ConnectionString)}";
         private readonly string StorageTypeKey = $"{nameof(BaGetOptions.Storage)}:{nameof(StorageOptions.Type)}";
         private readonly string FileSystemStoragePathKey = $"{nameof(BaGetOptions.Storage)}:{nameof(FileSystemStorageOptions.Path)}";
+        private readonly string SearchTypeKey = $"{nameof(BaGetOptions.Search)}:{nameof(SearchOptions.Type)}";
+        private readonly string MirrorEnabledKey = $"{nameof(BaGetOptions.Mirror)}:{nameof(MirrorOptions.Enabled)}";
 
         private ITestOutputHelper _helper;
         private LogLevel _minimumLevel = LogLevel.None;
@@ -83,6 +85,8 @@ namespace BaGet.Tests
             Configuration.Add(ConnectionStringKey, string.Format("Data Source={0}", resolvedSqliteFile));
             Configuration.Add(StorageTypeKey, StorageType.FileSystem.ToString());
             Configuration.Add(FileSystemStoragePathKey, storageFolderPath);
+            Configuration.Add(SearchTypeKey, nameof(SearchType.Database));
+            Configuration.Add(MirrorEnabledKey, false.ToString());
             return this;
         }
 


### PR DESCRIPTION
`/Versioned` looks like a leftover and this is definitely not the right version in any of the endpoints.
These changes were enough to fix paket install and update.

### What does this PR do?

 * Changes versions of resources in `index.json` to 3.0.0.
 * Adds trailing `/` in `PackageBaseAddress` and `RegistrationsBaseUrl` which were causing issues in paket too.

### Motivation

Currently running paket install or update would fail with
```
GetPackageDetails failed: System.Exception: Couldn't get package details for package baget-test1 1.0.0 on http://baget:9090/v3/index.json. ---> System.AggregateException: One or more errors occurred. ---> System.Exception: could not find an PackageIndex endpoint for http://baget:9090/v3/index.json
```
Which is caused by resource names in `index.json` being `RegistrationsBaseUrl/Versioned` rather than something like `RegistrationsBaseUrl/3.4.0`.

This is not passing all e2e tests yet.