### PR TITLE
Improve mirroring

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -57,10 +57,8 @@ steps:
     publishWebProjects: True
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
     zipAfterPublish: True
-  condition: eq(variables['build.sourcebranch'], 'refs/heads/master')
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifacts'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-  condition: eq(variables['build.sourcebranch'], 'refs/heads/master')

--- a/src/BaGet.Core/Mirror/FakeMirrorService.cs
+++ b/src/BaGet.Core/Mirror/FakeMirrorService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using BaGet.Core.Entities;
 using NuGet.Versioning;
 
 namespace BaGet.Core.Mirror
@@ -9,7 +11,17 @@ namespace BaGet.Core.Mirror
     /// </summary>
     public class FakeMirrorService : IMirrorService
     {
-        public Task MirrorAsync(string id, CancellationToken cancellationToken)
+        public Task<IReadOnlyList<NuGetVersion>> FindPackageVersionsOrNullAsync(string id, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<NuGetVersion>>(null);
+        }
+
+        public Task<IReadOnlyList<Package>> FindPackagesOrNullAsync(string id, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<Package>>(null);
+        }
+
+        public Task MirrorAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/BaGet.Core/Mirror/IMirrorService.cs
+++ b/src/BaGet.Core/Mirror/IMirrorService.cs
@@ -1,5 +1,8 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using BaGet.Core.Entities;
+using NuGet.Versioning;
 
 namespace BaGet.Core.Mirror
 {
@@ -9,11 +12,36 @@ namespace BaGet.Core.Mirror
     public interface IMirrorService
     {
         /// <summary>
+        /// Attempt to find a package's versions using mirroring. This will merge
+        /// results from the configured upstream source with the locally indexed packages.
+        /// </summary>
+        /// <param name="id">The package's id to lookup</param>
+        /// <param name="cancellationToken">The token to cancel the lookup</param>
+        /// <returns>
+        /// The package's versions, or null if the package cannot be found on the
+        /// configured upstream source. This includes unlisted versions.
+        /// </returns>
+        Task<IReadOnlyList<NuGetVersion>> FindPackageVersionsOrNullAsync(string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Attempt to find a package's metadata using mirroring. This will merge
+        /// results from the configured upstream source with the locally indexed packages.
+        /// </summary>
+        /// <param name="id">The package's id to lookup</param>
+        /// <param name="cancellationToken">The token to cancel the lookup</param>
+        /// <returns>
+        /// The package's metadata, or null if the package cannot be found on the configured
+        /// upstream source.
+        /// </returns>
+        Task<IReadOnlyList<Package>> FindPackagesOrNullAsync(string id, CancellationToken cancellationToken);
+
+        /// <summary>
         /// If the package is unknown, attempt to index it from an upstream source.
         /// </summary>
         /// <param name="id">The package's id</param>
+        /// <param name="version">The package's version</param>
         /// <param name="cancellationToken">The token to cancel the mirroring</param>
         /// <returns>A task that completes when the package has been mirrored.</returns>
-        Task MirrorAsync(string id, CancellationToken cancellationToken);
+        Task MirrorAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
     }
 }

--- a/src/BaGet.Core/Mirror/MirrorService.cs
+++ b/src/BaGet.Core/Mirror/MirrorService.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BaGet.Core.Entities;
 using BaGet.Core.Services;
 using BaGet.Protocol;
 using Microsoft.Extensions.Logging;
@@ -9,6 +11,8 @@ using NuGet.Versioning;
 
 namespace BaGet.Core.Mirror
 {
+    using PackageIdentity = NuGet.Packaging.Core.PackageIdentity;
+
     public class MirrorService : IMirrorService
     {
         private readonly IPackageService _localPackages;
@@ -31,68 +35,207 @@ namespace BaGet.Core.Mirror
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task MirrorAsync(string id, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<NuGetVersion>> FindPackageVersionsOrNullAsync(
+            string id,
+            CancellationToken cancellationToken)
         {
-            if (await _localPackages.ExistsAsync(id))
+            var versions = await _upstreamFeed.GetAllVersionsOrNullAsync(
+                id,
+                includeUnlisted: true,
+                cancellationToken: cancellationToken);
+            if (versions == null)
+            {
+                return versions;
+            }
+
+            // Merge the local package versions into the upstream package versions.
+            var localPackages = await _localPackages.FindAsync(id, includeUnlisted: true);
+            var localVersions = localPackages.Select(p => p.Version);
+
+            return versions.Concat(localVersions).Distinct().ToList();
+        }
+
+        public async Task<IReadOnlyList<Package>> FindPackagesOrNullAsync(string id, CancellationToken cancellationToken)
+        {
+            var upstreamPackageMetadata = await _upstreamFeed.GetAllMetadataOrNullAsync(id, cancellationToken);
+            if (upstreamPackageMetadata == null)
+            {
+                return null;
+            }
+
+            var upstreamPackages = upstreamPackageMetadata.Select(ToPackage);
+
+            // Return the upstream packages if there are no local packages matching the package id.
+            var localPackages = await _localPackages.FindAsync(id, includeUnlisted: true);
+            if (!localPackages.Any())
+            {
+                return upstreamPackages.ToList();
+            }
+
+            // Otherwise, merge the local packages into the upstream packages.
+            var result = upstreamPackages.ToDictionary(p => new PackageIdentity(p.Id, p.Version));
+            var local = localPackages.ToDictionary(p => new PackageIdentity(p.Id, p.Version));
+
+            foreach (var localPackage in local)
+            {
+                result[localPackage.Key] = localPackage.Value;
+            }
+
+            return result.Values.ToList();
+        }
+
+        public async Task MirrorAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+        {
+            if (await _localPackages.ExistsAsync(id, version))
             {
                 return;
             }
 
-            _logger.LogInformation("Package {PackageId} does not exist locally. Mirroring...", id);
+            _logger.LogInformation(
+                "Package {PackageId} {PackageVersion} does not exist locally. Indexing from upstream feed...",
+                id,
+                version);
 
-            var versions = await _upstreamFeed.GetAllVersionsAsync(id, includeUnlisted: true);
+            await IndexFromSourceAsync(id, version, cancellationToken);
 
             _logger.LogInformation(
-                "Found {VersionsCount} versions for package {PackageId} on upstream feed. Indexing...",
-                versions.Count,
-                id);
-
-            // TODO: This will synchronously index packages one-by-one. This won't perform well
-            // for packages with many versions. Instead, this should index a few packages and
-            // let a background queue index the rest.
-            // See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1#queued-background-tasks
-            foreach (var version in versions)
-            {
-                var packageUri = await _upstreamFeed.GetPackageContentUriAsync(id, version);
-
-                await IndexFromSourceAsync(packageUri, cancellationToken);
-            }
-
-            _logger.LogInformation("Finished indexing {PackageId} from the upstream feed", id);
+                "Finished indexing {PackageId} {PackageVersion} from the upstream feed",
+                id,
+                version);
         }
 
-        private async Task IndexFromSourceAsync(Uri packageUri, CancellationToken cancellationToken)
+        private Package ToPackage(PackageMetadata metadata)
+        {
+            return new Package
+            {
+                Id = metadata.PackageId,
+                Version = metadata.Version,
+                Authors = ParseAuthors(metadata.Authors),
+                Description = metadata.Description,
+                Downloads = metadata.Downloads,
+                HasReadme = metadata.HasReadme,
+                Language = metadata.Language,
+                Listed = metadata.Listed,
+                MinClientVersion = metadata.MinClientVersion,
+                Published = metadata.Published,
+                RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+                Summary = metadata.Summary,
+                Title = metadata.Title,
+                IconUrl = ParseUri(metadata.IconUrl),
+                LicenseUrl = ParseUri(metadata.LicenseUrl),
+                ProjectUrl = ParseUri(metadata.ProjectUrl),
+                RepositoryUrl = ParseUri(metadata.RepositoryUrl),
+                RepositoryType = metadata.RepositoryType,
+                Tags = metadata.Tags.ToArray(),
+
+                Dependencies = FindDependencies(metadata)
+            };
+        }
+
+        private Uri ParseUri(string uriString)
+        {
+            if (uriString == null) return null;
+
+            if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+            {
+                return null;
+            }
+
+            return uri;
+        }
+
+        private string[] ParseAuthors(string authors)
+        {
+            if (string.IsNullOrEmpty(authors)) return new string[0];
+
+            return authors
+                .Split(new[] { ',', ';', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(a => a.Trim())
+                .ToArray();
+        }
+
+        private List<PackageDependency> FindDependencies(PackageMetadata package)
+        {
+            if ((package.DependencyGroups?.Count ?? 0) == 0)
+            {
+                return new List<PackageDependency>();
+            }
+
+            return package.DependencyGroups
+                .SelectMany(FindDependenciesFromDependencyGroup)
+                .ToList();
+        }
+
+        private IEnumerable<PackageDependency> FindDependenciesFromDependencyGroup(DependencyGroupItem group)
+        {
+            // BaGet stores a dependency group with no dependencies as a package dependency
+            // with no package id nor package version.
+            if ((group.Dependencies?.Count ?? 0) == 0)
+            {
+                return new[]
+                {
+                    new PackageDependency
+                    {
+                        Id = null,
+                        VersionRange = null,
+                        TargetFramework = group.TargetFramework
+                    }
+                };
+            }
+
+            return group.Dependencies.Select(d => new PackageDependency
+            {
+                Id = d.Id,
+                VersionRange = d.Range,
+                TargetFramework = group.TargetFramework
+            });
+        }
+
+        private async Task IndexFromSourceAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            _logger.LogInformation("Attempting to mirror package {PackageUri}...", packageUri);
+            _logger.LogInformation(
+                "Attempting to mirror package {PackageId} {PackageVersion}...",
+                id,
+                version);
 
             try
             {
+                var packageUri = await _upstreamFeed.GetPackageContentUriAsync(id, version);
+
                 using (var stream = await _downloader.DownloadOrNullAsync(packageUri, cancellationToken))
                 {
                     if (stream == null)
                     {
                         _logger.LogWarning(
-                            "Failed to download package at {PackageUri}",
-                            packageUri);
+                            "Failed to download package {PackageId} {PackageVersion}",
+                            id,
+                            version);
 
                         return;
                     }
 
-                    _logger.LogInformation("Downloaded package at {PackageUri}, indexing...", packageUri);
+                    _logger.LogInformation(
+                        "Downloaded package {PackageId} {PackageVersion}, indexing...",
+                        id,
+                        version);
 
                     var result = await _indexer.IndexAsync(stream, cancellationToken);
 
                     _logger.LogInformation(
-                        "Finished indexing package at {PackageUri} with result {Result}",
+                        "Finished indexing package {PackageId} {PackageVersion} with result {Result}",
                         packageUri,
                         result);
                 }
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Failed to mirror package at {PackageUri}", packageUri);
+                _logger.LogError(
+                    e,
+                    "Failed to mirror package {PackageId} {PackageVersion}",
+                    id,
+                    version);
             }
         }
     }

--- a/src/BaGet.Core/Mirror/MirrorService.cs
+++ b/src/BaGet.Core/Mirror/MirrorService.cs
@@ -39,17 +39,15 @@ namespace BaGet.Core.Mirror
             string id,
             CancellationToken cancellationToken)
         {
-            var versions = await _upstreamFeed.GetAllVersionsOrNullAsync(
-                id,
-                includeUnlisted: true,
-                cancellationToken: cancellationToken);
+            var includeUnlisted = true;
+            var versions = await _upstreamFeed.GetAllVersionsOrNullAsync(id, includeUnlisted, cancellationToken);
             if (versions == null)
             {
-                return versions;
+                return null;
             }
 
             // Merge the local package versions into the upstream package versions.
-            var localPackages = await _localPackages.FindAsync(id, includeUnlisted: true);
+            var localPackages = await _localPackages.FindAsync(id, includeUnlisted);
             var localVersions = localPackages.Select(p => p.Version);
 
             return versions.Concat(localVersions).Distinct().ToList();

--- a/src/BaGet.Protocol/Registration/IRegistrationClient.cs
+++ b/src/BaGet.Protocol/Registration/IRegistrationClient.cs
@@ -4,7 +4,12 @@ namespace BaGet.Protocol
 {
     public interface IRegistrationClient
     {
-        Task<RegistrationIndex> GetRegistrationIndexAsync(string indexUrl);
+        /// <summary>
+        /// Attempt to get a package's registration index, if it exists.
+        /// </summary>
+        /// <param name="indexUrl">The url to load the registration index from</param>
+        /// <returns>The package's registration index, or null if the package does not exist</returns>
+        Task<RegistrationIndex> GetRegistrationIndexOrNullAsync(string indexUrl);
 
         Task<RegistrationIndexPage> GetRegistrationIndexPageAsync(string pageUrl);
 

--- a/src/BaGet.Protocol/Registration/PackageMetadata.cs
+++ b/src/BaGet.Protocol/Registration/PackageMetadata.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using BaGet.Protocol.Converters;
+using Newtonsoft.Json;
+using NuGet.Versioning;
+
+namespace BaGet.Protocol
+{
+    public class PackageMetadata
+    {
+        public PackageMetadata(
+            string catalogUri,
+            string packageId,
+            NuGetVersion version,
+            string authors,
+            string description,
+            long downloads,
+            bool hasReadme,
+            string iconUrl,
+            string language,
+            string licenseUrl,
+            bool listed,
+            string minClientVersion,
+            string packageContent,
+            string projectUrl,
+            string repositoryUrl,
+            string repositoryType,
+            DateTime published,
+            bool requireLicenseAcceptance,
+            string summary,
+            IReadOnlyList<string> tags,
+            string title,
+            IReadOnlyList<DependencyGroupItem> dependencyGroups)
+        {
+            CatalogUri = catalogUri ?? throw new ArgumentNullException(nameof(catalogUri));
+
+            PackageId = packageId;
+            Version = version;
+            Authors = authors;
+            Description = description;
+            Downloads = downloads;
+            HasReadme = hasReadme;
+            IconUrl = iconUrl;
+            Language = language;
+            LicenseUrl = licenseUrl;
+            Listed = listed;
+            MinClientVersion = minClientVersion;
+            PackageContent = packageContent;
+            ProjectUrl = projectUrl;
+            RepositoryUrl = repositoryUrl;
+            RepositoryType = repositoryType;
+            Published = published;
+            RequireLicenseAcceptance = requireLicenseAcceptance;
+            Summary = summary;
+            Tags = tags;
+            Title = title;
+            DependencyGroups = dependencyGroups;
+        }
+
+        [JsonProperty(PropertyName = "@id")]
+        public string CatalogUri { get; }
+
+        [JsonProperty(PropertyName = "id")]
+        public string PackageId { get; }
+
+        [JsonConverter(typeof(NuGetVersionConverter))]
+        public NuGetVersion Version { get; }
+
+        public string Authors { get; }
+        public string Description { get; }
+        public long Downloads { get; }
+        public bool HasReadme { get; }
+        public string IconUrl { get; }
+        public string Language { get; }
+        public string LicenseUrl { get; }
+        public bool Listed { get; }
+        public string MinClientVersion { get; }
+        public string PackageContent { get; }
+        public string ProjectUrl { get; }
+        public string RepositoryUrl { get; }
+        public string RepositoryType { get; }
+        public DateTime Published { get; }
+        public bool RequireLicenseAcceptance { get; }
+        public string Summary { get; }
+        public IReadOnlyList<string> Tags { get; }
+        public string Title { get; }
+        public IReadOnlyList<DependencyGroupItem> DependencyGroups { get; }
+    }
+
+    public class DependencyGroupItem
+    {
+        public DependencyGroupItem(
+            string id,
+            string targetFramework,
+            IReadOnlyList<DependencyItem> dependencies)
+        {
+            Id = id;
+            Type = "PackageDependencyGroup";
+            TargetFramework = targetFramework;
+            Dependencies = (dependencies?.Count > 0) ? dependencies : null;
+        }
+
+        [JsonProperty(PropertyName = "@id")]
+        public string Id { get; }
+
+        [JsonProperty(PropertyName = "@type")]
+        public string Type { get; }
+
+        public string TargetFramework { get; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public IReadOnlyList<DependencyItem> Dependencies { get; }
+    }
+
+    public class DependencyItem
+    {
+        [JsonProperty(PropertyName = "@id")]
+        public string DepId { get; }
+
+        [JsonProperty(PropertyName = "@type")]
+        public string Type { get; }
+
+        public string Id { get; }
+        public string Range { get; }
+
+        public DependencyItem(string depId, string id, string range)
+        {
+            DepId = depId;
+            Type = "PackageDependency";
+            Id = id;
+            Range = range;
+        }
+    }
+}

--- a/src/BaGet.Protocol/Registration/RegistrationClient.cs
+++ b/src/BaGet.Protocol/Registration/RegistrationClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -13,9 +14,13 @@ namespace BaGet.Protocol
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        public async Task<RegistrationIndex> GetRegistrationIndexAsync(string indexUrl)
+        public async Task<RegistrationIndex> GetRegistrationIndexOrNullAsync(string indexUrl)
         {
             var response = await _httpClient.GetAsync(indexUrl);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
 
             response.EnsureSuccessStatusCode();
 

--- a/src/BaGet.Protocol/Registration/RegistrationIndexPageItem.cs
+++ b/src/BaGet.Protocol/Registration/RegistrationIndexPageItem.cs
@@ -1,153 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using BaGet.Protocol.Converters;
 using Newtonsoft.Json;
-using NuGet.Versioning;
 
 namespace BaGet.Protocol
 {
     public class RegistrationIndexPageItem
     {
-        public RegistrationIndexPageItem(string leafUrl, CatalogEntry catalogEntry, string packageContent)
+        public RegistrationIndexPageItem(string leafUrl, PackageMetadata packageMetadata, string packageContent)
         {
             if (string.IsNullOrEmpty(leafUrl)) throw new ArgumentNullException(nameof(leafUrl));
 
             LeafUrl = leafUrl;
-            CatalogEntry = catalogEntry ?? throw new ArgumentNullException(nameof(catalogEntry));
+            PackageMetadata = packageMetadata ?? throw new ArgumentNullException(nameof(packageMetadata));
             PackageContent = packageContent ?? throw new ArgumentNullException(nameof(packageContent));
         }
 
         [JsonProperty(PropertyName = "@id")]
         public string LeafUrl { get; }
 
-        public CatalogEntry CatalogEntry { get; }
+        [JsonProperty(PropertyName = "catalogEntry")]
+        public PackageMetadata PackageMetadata { get; }
 
         public string PackageContent { get; }
-    }
-
-    public class CatalogEntry
-    {
-        public CatalogEntry(
-            string catalogUri,
-            string packageId,
-            NuGetVersion version,
-            string authors,
-            string description,
-            long downloads,
-            bool hasReadme,
-            string iconUrl,
-            string language,
-            string licenseUrl,
-            bool listed,
-            string minClientVersion,
-            string packageContent,
-            string projectUrl,
-            string repositoryUrl,
-            string repositoryType,
-            DateTime published,
-            bool requireLicenseAcceptance,
-            string summary,
-            IReadOnlyList<string> tags,
-            string title,
-            IReadOnlyList<DependencyGroupItem> dependencyGroups)
-        {
-            CatalogUri = catalogUri ?? throw new ArgumentNullException(nameof(catalogUri));
-
-            PackageId = packageId;
-            Version = version;
-            Authors = authors;
-            Description = description;
-            Downloads = downloads;
-            HasReadme = hasReadme;
-            IconUrl = iconUrl;
-            Language = language;
-            LicenseUrl = licenseUrl;
-            Listed = listed;
-            MinClientVersion = minClientVersion;
-            PackageContent = packageContent;
-            ProjectUrl = projectUrl;
-            RepositoryUrl = repositoryUrl;
-            RepositoryType = repositoryType;
-            Published = published;
-            RequireLicenseAcceptance = requireLicenseAcceptance;
-            Summary = summary;
-            Tags = tags;
-            Title = title;
-            DependencyGroups = dependencyGroups;
-        }
-
-        [JsonProperty(PropertyName = "@id")]
-        public string CatalogUri { get; }
-
-        [JsonProperty(PropertyName = "id")]
-        public string PackageId { get; }
-
-        [JsonConverter(typeof(NuGetVersionConverter))]
-        public NuGetVersion Version { get; }
-
-        public string Authors { get; }
-        public string Description { get; }
-        public long Downloads { get; }
-        public bool HasReadme { get; }
-        public string IconUrl { get; }
-        public string Language { get; }
-        public string LicenseUrl { get; }
-        public bool Listed { get; }
-        public string MinClientVersion { get; }
-        public string PackageContent { get; }
-        public string ProjectUrl { get; }
-        public string RepositoryUrl { get; }
-        public string RepositoryType { get; }
-        public DateTime Published { get; }
-        public bool RequireLicenseAcceptance { get; }
-        public string Summary { get; }
-        public IReadOnlyList<string> Tags { get; }
-        public string Title { get; }
-        public IReadOnlyList<DependencyGroupItem> DependencyGroups { get; }
-    }
-
-    public class DependencyGroupItem
-    {
-        public DependencyGroupItem(
-            string id,
-            string targetFramework,
-            IReadOnlyList<DependencyItem> dependencyItems)
-        {
-            Id = id;
-            Type = "PackageDependencyGroup";
-            TargetFramework = targetFramework;
-            Dependencies = (dependencyItems?.Count > 0) ? dependencyItems : null;
-        }
-
-        [JsonProperty(PropertyName = "@id")]
-        public string Id { get; }
-
-        [JsonProperty(PropertyName = "@type")]
-        public string Type { get; }
-
-        public string TargetFramework { get; }
-
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public IReadOnlyList<DependencyItem> Dependencies { get; }
-    }
-
-    public class DependencyItem
-    {
-        [JsonProperty(PropertyName = "@id")]
-        public string DepId { get; }
-
-        [JsonProperty(PropertyName = "@type")]
-        public string Type { get; }
-
-        public string Id { get; }
-        public string Range { get; }
-
-        public DependencyItem(string groupId, string depId, string versionRange)
-        {
-            DepId = groupId + "/" + depId;
-            Type = "PackageDependency";
-            Id = depId;
-            Range = versionRange;
-        }
     }
 }

--- a/src/BaGet.Protocol/Services/IPackageMetadataService.cs
+++ b/src/BaGet.Protocol/Services/IPackageMetadataService.cs
@@ -12,23 +12,33 @@ namespace BaGet.Protocol
     public interface IPackageMetadataService
     {
         /// <summary>
-        /// Get all versions of a package from a remote NuGet feed.
-        /// </summary>
-        /// <param name="packageId">The package whose versions should be fetched.</param>
-        /// <param name="includeUnlisted">Whether results should include unlisted versions.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>All versions for the package.</returns>
-        Task<IReadOnlyList<NuGetVersion>> GetAllVersionsAsync(
-            string packageId,
-            bool includeUnlisted = false,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Get the URI to download a package's content from a remote NuGet feed.
         /// </summary>
         /// <param name="packageId">The package whose URL should be fetched.</param>
         /// <param name="version">The package's version whose uRL should be fetched.</param>
         /// <returns>A URI that can be used to download the package.</returns>
         Task<Uri> GetPackageContentUriAsync(string packageId, NuGetVersion version);
+
+        /// <summary>
+        /// Get the metadata for each versions of a package from a remote NuGet feed.
+        /// </summary>
+        /// <param name="packageId">The package to look up</param>
+        /// <param name="cancellationToken">A token to cancel the lookup</param>
+        /// <returns>Metadata for each version of the package, or null if the package doesn't exist</returns>
+        Task<IReadOnlyList<PackageMetadata>> GetAllMetadataOrNullAsync(
+            string packageId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all versions of a package from a remote NuGet feed.
+        /// </summary>
+        /// <param name="packageId">The package whose versions should be fetched.</param>
+        /// <param name="includeUnlisted">Whether results should include unlisted versions.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>All versions for the package, or null if the package doesn't exist.</returns>
+        Task<IReadOnlyList<NuGetVersion>> GetAllVersionsOrNullAsync(
+            string packageId,
+            bool includeUnlisted = false,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/BaGet/Controllers/Registration/RegistrationLeafController.cs
+++ b/src/BaGet/Controllers/Registration/RegistrationLeafController.cs
@@ -34,9 +34,9 @@ namespace BaGet.Controllers.Registration
             }
 
             // Allow read-through caching to happen if it is configured.
-            await _mirror.MirrorAsync(id, cancellationToken);
+            await _mirror.MirrorAsync(id, nugetVersion, cancellationToken);
 
-            var package = await _packages.FindOrNullAsync(id, nugetVersion);
+            var package = await _packages.FindOrNullAsync(id, nugetVersion, includeUnlisted: true);
 
             if (package == null)
             {

--- a/tests/BaGet.Protocol.Tests/PackageMetadataServiceIntegrationTests.cs
+++ b/tests/BaGet.Protocol.Tests/PackageMetadataServiceIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace BaGet.Protocol.Tests
         [InlineData(true)]
         public async Task GetsAllVersionsForNewtonsoftJson(bool includeUnlisted)
         {
-            var result = await _target.GetAllVersionsAsync("Newtonsoft.Json", includeUnlisted);
+            var result = await _target.GetAllVersionsOrNullAsync("Newtonsoft.Json", includeUnlisted);
 
             Assert.NotEmpty(result);
         }
@@ -39,7 +39,7 @@ namespace BaGet.Protocol.Tests
         [InlineData(true)]
         public async Task GetsAllVersionsForFake(bool includeUnlisted)
         {
-            var result = await _target.GetAllVersionsAsync("Fake", includeUnlisted);
+            var result = await _target.GetAllVersionsOrNullAsync("Fake", includeUnlisted);
         }
     }
 }

--- a/tests/BaGet.Protocol.Tests/RegistrationClientTests.cs
+++ b/tests/BaGet.Protocol.Tests/RegistrationClientTests.cs
@@ -20,7 +20,7 @@ namespace BaGet.Protocol.Tests
         {
             var url = "https://api.nuget.org/v3/registration3/newtonsoft.json/index.json";
 
-            var result = await _target.GetRegistrationIndexAsync(url);
+            var result = await _target.GetRegistrationIndexOrNullAsync(url);
 
             Assert.NotNull(result);
             Assert.Equal(1, result.Pages.Count);
@@ -35,7 +35,7 @@ namespace BaGet.Protocol.Tests
         {
             var url = "https://api.nuget.org/v3/registration3/fake/index.json";
 
-            var result = await _target.GetRegistrationIndexAsync(url);
+            var result = await _target.GetRegistrationIndexOrNullAsync(url);
 
             Assert.NotNull(result);
             Assert.True(result.Pages.Count >= 27);
@@ -50,7 +50,7 @@ namespace BaGet.Protocol.Tests
         {
             var url = "https://api.nuget.org/v3/registration3/fake/index.json";
 
-            var index = await _target.GetRegistrationIndexAsync(url);
+            var index = await _target.GetRegistrationIndexOrNullAsync(url);
             var result = await _target.GetRegistrationIndexPageAsync(index.Pages[0].PageUrl);
 
             Assert.NotNull(result);
@@ -64,7 +64,7 @@ namespace BaGet.Protocol.Tests
         {
             var url = "https://api.nuget.org/v3/registration3/newtonsoft.json/index.json";
 
-            var index = await _target.GetRegistrationIndexAsync(url);
+            var index = await _target.GetRegistrationIndexOrNullAsync(url);
             var leaf = await _target.GetRegistrationLeafAsync(index.Pages[0].ItemsOrNull[0].LeafUrl);
 
             Assert.Equal(url, leaf.RegistrationIndexUrl);
@@ -75,7 +75,7 @@ namespace BaGet.Protocol.Tests
         {
             var url = "https://api.nuget.org/v3/registration3/fake/index.json";
 
-            var index = await _target.GetRegistrationIndexAsync(url);
+            var index = await _target.GetRegistrationIndexOrNullAsync(url);
             var page = await _target.GetRegistrationIndexPageAsync(index.Pages[0].PageUrl);
             var leaf = await _target.GetRegistrationLeafAsync(page.ItemsOrNull[0].LeafUrl);
 


### PR DESCRIPTION
Improve mirroring. The registration index will now always find all versions listed on the upstream source. This is based off @tomzo's work from their fork of BaGet.