### PR TITLE
Improve the display package UI

### DIFF
--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -1,6 +1,7 @@
 import { HtmlRenderer, Parser } from 'commonmark';
 import * as React from 'react';
 import timeago from 'timeago.js';
+import LicenseInfo from './LicenseInfo';
 import SourceRepository from './SourceRepository';
 
 import './DisplayPackage.css';
@@ -182,12 +183,13 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             <div>
               <h1>Info</h1>
 
-              <div>last updated {timeago().format(this.state.package.lastUpdate)}</div>
+              <div>Last updated {timeago().format(this.state.package.lastUpdate)}</div>
               <div><a href={this.state.package.projectUrl}>{this.state.package.projectUrl}</a></div>
 
               <SourceRepository url={this.state.package.repositoryUrl} type={this.state.package.repositoryType} />
+              <LicenseInfo url={this.state.package.licenseUrl} />
 
-              <div><a href={this.state.package.licenseUrl}>License Info</a></div>
+              <div><a href={this.state.package.downloadUrl}>Download Package</a></div>
             </div>
 
             <div>

--- a/src/BaGet.UI/src/LicenseInfo.tsx
+++ b/src/BaGet.UI/src/LicenseInfo.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+interface ILicenseInfoProps {
+  url: string;
+}
+
+class LicenseInfo extends React.Component<ILicenseInfoProps> {
+
+  constructor(props: ILicenseInfoProps) {
+    super(props);
+
+    this.state = {items: []};
+  }
+
+  public render() {
+    if (!this.props.url) {
+        return null;
+    }
+
+    return (
+        <div>
+            <a href={this.props.url}>License Info</a>
+        </div>
+    );
+  }
+}
+
+export default LicenseInfo;

--- a/tests/BaGet.Protocol.Tests/RegistrationClientTests.cs
+++ b/tests/BaGet.Protocol.Tests/RegistrationClientTests.cs
@@ -23,11 +23,11 @@ namespace BaGet.Protocol.Tests
             var result = await _target.GetRegistrationIndexOrNullAsync(url);
 
             Assert.NotNull(result);
-            Assert.Equal(1, result.Pages.Count);
-            Assert.True(result.Pages[0].Count >= 63);
-            Assert.True(result.Pages[0].ItemsOrNull.Count >= 63);
+            Assert.Equal(2, result.Pages.Count);
+            Assert.True(result.Pages[0].Count == 64);
+            Assert.True(result.Pages[0].ItemsOrNull.Count == 64);
             Assert.Equal(new NuGetVersion("3.5.8"), result.Pages[0].Lower);
-            Assert.Equal(new NuGetVersion("12.0.1-beta1"), result.Pages[0].Upper);
+            Assert.Equal(new NuGetVersion("12.0.1-beta2"), result.Pages[0].Upper);
         }
 
         [Fact]

--- a/tests/BaGet.Protocol.Tests/SearchClientTests.cs
+++ b/tests/BaGet.Protocol.Tests/SearchClientTests.cs
@@ -27,7 +27,7 @@ namespace BaGet.Protocol.Tests
             Assert.True(result.Data.Count > 0);
             Assert.Equal(registrationurl, result.Data[0].RegistrationUrl);
             Assert.Equal("Newtonsoft.Json", result.Data[0].Id);
-            Assert.Equal(new NuGetVersion("11.0.2"), result.Data[0].Version);
+            Assert.Equal(new NuGetVersion("12.0.1"), result.Data[0].Version);
         }
 
         [Fact]


### PR DESCRIPTION
Adds a Package Download link and removes the License Info link when a package has no license.

Addresses  the issues https://github.com/loic-sharma/BaGet/issues/138 and https://github.com/loic-sharma/BaGet/issues/141 found by @LordMike.