### PR TITLE
Add UI for dependency lists

### DIFF
--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -74,13 +74,13 @@ interface ICatalogEntry {
 }
 
 interface IDependencyGroup {
-    targetFramework: string;
-    dependencies: IDependency[];
+  targetFramework: string;
+  dependencies: IDependency[];
 }
 
 interface IDependency {
-    id: string;
-    range: string;
+  id: string;
+  range: string;
 }
 
 class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPackageState> {
@@ -118,14 +118,14 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
           version: entry.catalogEntry.version,
         });
 
-        dependencyGroups.push(...entry.catalogEntry.dependencyGroups);
-
         if (entry.catalogEntry.version === latestVersion) {
           latestItem = entry;
         }
       }
 
       if (latestItem) {
+        dependencyGroups.push(...latestItem.catalogEntry.dependencyGroups);
+
         let readme = "";
         if (!latestItem.catalogEntry.hasReadme) {
           readme = latestItem.catalogEntry.description; 

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -26,6 +26,7 @@ interface IPackage {
   authors: string;
   tags: string[];
   versions: IPackageVersion[];
+  dependencyGroups: IDependencyGroup[];
 }
 
 interface IPackageVersion {
@@ -69,6 +70,17 @@ interface ICatalogEntry {
   repositoryType: string;
   authors: string;
   tags: string[];
+  dependencyGroups: IDependencyGroup[];
+}
+
+interface IDependencyGroup {
+    targetFramework: string;
+    dependencies: IDependency[];
+}
+
+interface IDependency {
+    id: string;
+    range: string;
 }
 
 class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPackageState> {
@@ -97,6 +109,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       let latestItem: IRegistrationPageItem | undefined;
 
       const versions: IPackageVersion[] = [];
+      const dependencyGroups: IDependencyGroup[] = [];
 
       for (const entry of results.items[0].items) {
         versions.push({
@@ -104,6 +117,8 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
           downloads: entry.catalogEntry.downloads,
           version: entry.catalogEntry.version,
         });
+
+        dependencyGroups.push(...entry.catalogEntry.dependencyGroups);
 
         if (entry.catalogEntry.version === latestVersion) {
           latestItem = entry;
@@ -119,6 +134,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
         this.setState({
           package: {
             authors: latestItem.catalogEntry.authors,
+            dependencyGroups,
             downloadUrl: latestItem.packageContent,
             iconUrl: latestItem.catalogEntry.iconUrl,
             id: latestItem.catalogEntry.id,
@@ -132,7 +148,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             repositoryUrl: latestItem.catalogEntry.repositoryUrl,
             tags: latestItem.catalogEntry.tags,
             totalDownloads: results.totalDownloads,
-            versions,
+            versions
           }
         });
 
@@ -177,7 +193,24 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             </div>
 
             {/* TODO: Fix this */}
-            <div dangerouslySetInnerHTML={ {__html: this.state.package.readme} } />
+            <div dangerouslySetInnerHTML={{ __html: this.state.package.readme }} />
+
+            <div>
+                <h3>Dependencies</h3>
+
+                {this.state.package.dependencyGroups.map(depGroup => (
+                    <div>
+                        <h4>{depGroup.targetFramework}</h4>
+                        <ul>
+                            {depGroup.dependencies.map(dep => (
+                                <li>
+                                    {dep.id} {dep.range}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ))}
+            </div>
           </article>
           <aside className="col-sm-3 package-details-info">
             <div>

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -206,13 +206,17 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
                   {this.state.package.dependencyGroups.map(depGroup => (
                     <div key={depGroup.targetFramework}>
                       <h4>{depGroup.targetFramework}</h4>
-                      <ul>
-                        {depGroup.dependencies.map(dep => (
-                          <li key={dep.id}>
-                            {dep.id} {dep.range}
-                          </li>
-                        ))}
-                      </ul>
+                      {depGroup.dependencies.length > 0 ? (
+                        <ul>
+                          {depGroup.dependencies.map(dep => (
+                            <li key={dep.id}>
+                              {dep.id} {dep.range}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div>No dependencies.</div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -195,22 +195,24 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             {/* TODO: Fix this */}
             <div dangerouslySetInnerHTML={{ __html: this.state.package.readme }} />
 
+            {this.state.package.dependencyGroups.length > 0 && 
             <div>
-                <h3>Dependencies</h3>
+              <h3>Dependencies</h3>
 
-                {this.state.package.dependencyGroups.map(depGroup => (
-                    <div>
-                        <h4>{depGroup.targetFramework}</h4>
-                        <ul>
-                            {depGroup.dependencies.map(dep => (
-                                <li>
-                                    {dep.id} {dep.range}
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                ))}
+              {this.state.package.dependencyGroups.map(depGroup => (
+                  <div>
+                      <h4>{depGroup.targetFramework}</h4>
+                      <ul>
+                          {depGroup.dependencies.map(dep => (
+                              <li>
+                                  {dep.id} {dep.range}
+                              </li>
+                          ))}
+                      </ul>
+                  </div>
+              ))}
             </div>
+            }
           </article>
           <aside className="col-sm-3 package-details-info">
             <div>

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -109,7 +109,6 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       let latestItem: IRegistrationPageItem | undefined;
 
       const versions: IPackageVersion[] = [];
-      const dependencyGroups: IDependencyGroup[] = [];
 
       for (const entry of results.items[0].items) {
         versions.push({
@@ -124,8 +123,12 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       }
 
       if (latestItem) {
-        dependencyGroups.push(...latestItem.catalogEntry.dependencyGroups);
-
+        latestItem.catalogEntry.dependencyGroups.map(group => {
+          if (!group.dependencies) {
+            group.dependencies = [];
+          }
+        });
+        
         let readme = "";
         if (!latestItem.catalogEntry.hasReadme) {
           readme = latestItem.catalogEntry.description; 
@@ -134,7 +137,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
         this.setState({
           package: {
             authors: latestItem.catalogEntry.authors,
-            dependencyGroups,
+            dependencyGroups: latestItem.catalogEntry.dependencyGroups,
             downloadUrl: latestItem.packageContent,
             iconUrl: latestItem.catalogEntry.iconUrl,
             id: latestItem.catalogEntry.id,
@@ -199,18 +202,20 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
               <h3>Dependencies</h3>
 
               {this.state.package.dependencyGroups.length > 0 ? (
-                <div>{this.state.package.dependencyGroups.map(depGroup => (
-                  <div>
-                    <h4>{depGroup.targetFramework}</h4>
-                    <ul>
-                      {depGroup.dependencies.map(dep => (
-                        <li>
-                          {dep.id} {dep.range}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}</div>
+                <div>
+                  {this.state.package.dependencyGroups.map(depGroup => (
+                    <div key={depGroup.targetFramework}>
+                      <h4>{depGroup.targetFramework}</h4>
+                      <ul>
+                        {depGroup.dependencies.map(dep => (
+                          <li key={dep.id}>
+                            {dep.id} {dep.range}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
                 ) : (
                 <div>This package has no dependencies.</div>
               )}

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -198,22 +198,23 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             <div>
               <h3>Dependencies</h3>
 
-              {this.state.package.dependencyGroups.length > 0 ? ( 
-                {this.state.package.dependencyGroups.map(depGroup => (
-                    <div>
-                        <h4>{depGroup.targetFramework}</h4>
-                        <ul>
-                            {depGroup.dependencies.map(dep => (
-                                <li>
-                                    {dep.id} {dep.range}
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                ))}) : (
-			    This package has no dependencies.
-			  )}
-			</div>
+              {this.state.package.dependencyGroups.length > 0 ? (
+                <div>{this.state.package.dependencyGroups.map(depGroup => (
+                  <div>
+                    <h4>{depGroup.targetFramework}</h4>
+                    <ul>
+                      {depGroup.dependencies.map(dep => (
+                        <li>
+                          {dep.id} {dep.range}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}</div>
+                ) : (
+                <div>This package has no dependencies.</div>
+              )}
+          </div>
           </article>
           <aside className="col-sm-3 package-details-info">
             <div>

--- a/src/BaGet.UI/src/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage.tsx
@@ -195,24 +195,25 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             {/* TODO: Fix this */}
             <div dangerouslySetInnerHTML={{ __html: this.state.package.readme }} />
 
-            {this.state.package.dependencyGroups.length > 0 && 
             <div>
               <h3>Dependencies</h3>
 
-              {this.state.package.dependencyGroups.map(depGroup => (
-                  <div>
-                      <h4>{depGroup.targetFramework}</h4>
-                      <ul>
-                          {depGroup.dependencies.map(dep => (
-                              <li>
-                                  {dep.id} {dep.range}
-                              </li>
-                          ))}
-                      </ul>
-                  </div>
-              ))}
-            </div>
-            }
+              {this.state.package.dependencyGroups.length > 0 ? ( 
+                {this.state.package.dependencyGroups.map(depGroup => (
+                    <div>
+                        <h4>{depGroup.targetFramework}</h4>
+                        <ul>
+                            {depGroup.dependencies.map(dep => (
+                                <li>
+                                    {dep.id} {dep.range}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ))}) : (
+			    This package has no dependencies.
+			  )}
+			</div>
           </article>
           <aside className="col-sm-3 package-details-info">
             <div>


### PR DESCRIPTION
Fixes #157

![image](https://user-images.githubusercontent.com/1027111/49615621-7194c100-f9ae-11e8-8313-f55a76a4f783.png)

TODO:

* If the version ranges should be something human friendly, `>= 1.0.0`, it needs to be provided by the API ?
* Making links for packages this feed knows off (API change?)
* Adding info on packages linking back to this one (API change?)

I *will* note that I have no idea how to do Typescript - so this was fun :P... How do you, @loic-sharma, work on the UI? .. The files are not referenced in the solution, so VS has a hard time resolving all references.. 

Also, the indentation was off by a lot, so I had to manually adjust after VS/Resharper had their go at "fixing" things.