### PR TITLE
Added env var to specify other appsettings

### DIFF
--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -56,14 +56,9 @@ namespace BaGet
                 })
                 .ConfigureAppConfiguration((builderContext, config) =>
                 {
-                    var root = Environment.GetEnvironmentVariable("APPSETTINGS_ROOT");
+                    var root = Environment.GetEnvironmentVariable("BAGET_CONFIG_ROOT");
                     if (!string.IsNullOrEmpty(root))
-                    {
-                        var env = builderContext.HostingEnvironment;
-                        config.Sources.Clear();
-                        config.AddJsonFile($"{root}/appsettings.json", optional: false, reloadOnChange: true)
-                            .AddJsonFile($"{root}/appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
-                    }
+                        config.SetBasePath(root);
                 });
 
         public static IHostBuilder CreateHostBuilder(string[] args)

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -1,8 +1,10 @@
-﻿using BaGet.Core.Mirror;
+using System;
+using BaGet.Core.Mirror;
 using BaGet.Extensions;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -51,6 +53,17 @@ namespace BaGet
                     // Remove the upload limit from Kestrel. If needed, an upload limit can
                     // be enforced by a reverse proxy server, like IIS.
                     options.Limits.MaxRequestBodySize = null;
+                })
+                .ConfigureAppConfiguration((builderContext, config) =>
+                {
+                    var root = Environment.GetEnvironmentVariable("APPSETTINGS_ROOT");
+                    if (!string.IsNullOrEmpty(root))
+                    {
+                        var env = builderContext.HostingEnvironment;
+                        config.Sources.Clear();
+                        config.AddJsonFile($"{root}/appsettings.json", optional: false, reloadOnChange: true)
+                            .AddJsonFile($"{root}/appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+                    }
                 });
 
         public static IHostBuilder CreateHostBuilder(string[] args)


### PR DESCRIPTION
### What does this PR do?

By launching the app with environment variable `APPSETTINGS_ROOT` set that folder will be used to look for appsettings.json files.

### Motivation

The appsettings.json file contains sensitive information. We are hosting on Kubernetes and are mounting sensitive settings and certificates in a secret volume. This mount, and thus it files, cant go in the root, they need a subfolder. As such, I need a way to override where it looks for the settings file. There might be a more elegant way to do this.