### PR TITLE
Added support for acting like a Chocolatey server.

### DIFF
--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.1.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet/Controllers/PackagesV2Controller.cs
+++ b/src/BaGet/Controllers/PackagesV2Controller.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGet.Core.Entities;
+using BaGet.Core.Services;
+using BaGet.Legacy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using NuGet.Versioning;
+
+namespace BaGet.Controllers
+{
+    public class PackagesV2Controller : Controller
+    {
+        static readonly string apiKeyHeader = "X-NuGet-ApiKey";
+        static readonly string atomXmlContentType = "application/atom+xml";
+        static readonly string basePath = "/v2";
+
+        private readonly IAuthenticationService _authentication;
+        private readonly IPackageIndexingService _indexer;
+        private readonly IPackageService _packages;
+        private readonly IPackageDeletionService _deletion;
+        private readonly IODataPackageSerializer _serializer;
+        private readonly IPackageService _packageService;
+        private readonly IPackageStorageService _storage;
+        private readonly IEdmModel _odataModel;
+        private readonly ILogger<PackagesV2Controller> _log;
+
+        public PackagesV2Controller(
+            IAuthenticationService authentication,
+            IPackageIndexingService indexer,
+            IPackageService packages,
+            IPackageDeletionService deletion,
+            IODataPackageSerializer serializer,
+            IPackageService packageService,
+            IPackageStorageService storage,
+            IEdmModel odataModel,
+            ILogger<PackagesV2Controller> logger)
+        {
+            _authentication = authentication;
+            _indexer = indexer;
+            _packages = packages;
+            _deletion = deletion;
+            _serializer = serializer;
+            _packageService = packageService;
+            _storage = storage;
+            _odataModel = odataModel;
+            _log = logger;
+        }
+
+        public async Task<IActionResult> DownloadPackage(string id, string version)
+        {
+            if (!NuGetVersion.TryParse(version, out var nugetVersion))
+            {
+                return BadRequest();
+            }
+
+            if (!await _packageService.AddDownloadAsync(id, nugetVersion))
+            {
+                return BadRequest();
+            }
+
+            var packageStream = await _storage.GetPackageStreamAsync(id, nugetVersion, CancellationToken.None);
+            return File(packageStream, "application/octet-stream");
+        }
+
+        [HttpGet]
+        public async Task Index()
+        {
+            var serviceUrl = GetServiceUrl(Request);
+            var text = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<service xml:base=""{serviceUrl}"" xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom""><workspace>
+<atom:title type=""text"">Default</atom:title><collection href=""Packages""><atom:title type=""text"">Packages</atom:title></collection></workspace>
+</service>";
+            Response.StatusCode = 200;
+            Response.ContentType = "application/xml; charset=utf-8";
+            await Response.WriteAsync(text, new UTF8Encoding(false));
+        }
+
+        public async Task<IActionResult> FindPackagesById()
+        {
+            try
+            {
+                var serviceUrl = GetServiceUrl(Request);
+                var uriParser = new ODataUriParser(_odataModel, new Uri(serviceUrl), GetUri(Request));
+                var path = uriParser.ParsePath();
+                if (path.FirstSegment.Identifier == "FindPackagesById")
+                {
+                    var idOrNull = uriParser.CustomQueryOptions.FirstOrDefault(o => o.Key.ToLowerInvariant() == "id").Value;
+                    var id = idOrNull.TrimStart('\'').TrimEnd('\'');
+                    _log.LogDebug("Request to FindPackagesById id={0}", id);
+                    var found = await _packageService.FindAsync(id);
+                    var odata = new ODataResponse<IEnumerable<PackageWithUrls>>(serviceUrl, found.Select(f => ToPackageWithUrls(Request, f)));
+                    var ms = new MemoryStream();
+                    _serializer.Serialize(ms, odata.Entity, odata.ServiceBaseUrl);
+                    ms.Seek(0, SeekOrigin.Begin);
+                    return File(ms, atomXmlContentType);
+                }
+                return BadRequest();
+            }
+            catch (ODataException odataPathError)
+            {
+                _log.LogError("Bad odata query", odataPathError);
+                return BadRequest();
+            }
+        }
+
+        public async Task<IActionResult> QueryPackages()
+        {
+            try
+            {
+                var serviceUrl = GetServiceUrl(Request);
+                var uri = GetUri(Request);
+                var uriParser = new ODataUriParser(_odataModel, new Uri(serviceUrl), uri);
+                var path = uriParser.ParsePath();
+                if (path.FirstSegment.Identifier == "Packages")
+                {
+                    if (path.Count == 2 && path.LastSegment is KeySegment)
+                    {
+                        KeySegment queryParams = (KeySegment)path.LastSegment;
+                        var id = queryParams.Keys.First(k => k.Key == "Id").Value as string;
+                        var version = queryParams.Keys.First(k => k.Key == "Version").Value as string;
+                        _log.LogDebug("Request to find package by id={0} and version={1}", id, version);
+                        var nugetVersion = NuGetVersion.Parse(version);
+                        var found = await _packageService.FindOrNullAsync(id, nugetVersion);
+                        if (found == null)
+                        {
+                            return NotFound();
+                        }
+                        return ToODataStream(found);
+                    }
+                    else // might be Chocolatey, uses url like: /v2/Packages()?$filter=tolower(Id) eq 'package-id'&$orderby=Id  
+                    {
+                        var filter = uriParser.ParseFilter().Expression;
+                        var binary = (BinaryOperatorNode)filter;
+                        var leftParam = ((SingleValueFunctionCallNode)binary.Left).Parameters.First();
+                        var convert = (ConvertNode)leftParam;
+                        var prop = (SingleValuePropertyAccessNode)convert.Source;
+                        if (prop.Property.Name == "Id")
+                        {
+                            var id = ((ConstantNode)binary.Right).Value.ToString();
+                            var packages = await _packageService.FindAsync(id);
+                            var found = packages.OrderBy(x => x.Version).LastOrDefault();
+                            if (found == null)
+                            {
+                                return NotFound();
+                            }
+                            return ToODataStream(found);
+                        }
+                    }
+
+                    // rest of OData support would go here
+                }
+            }
+            catch (ODataException odataPathError)
+            {
+                _log.LogError("Bad odata query", odataPathError);
+                return BadRequest();
+            }
+            return BadRequest();
+        }
+
+        [HttpPut]
+        public async Task PutPackage()
+        {
+            CancellationToken ct = CancellationToken.None;
+            Stream uploadStream;
+            if (Request.Form.Files.Count > 0)
+            {
+                // If we're using the newer API, the package stream is sent as a file.
+                // use first and ignore the rest
+                // as in https://docs.microsoft.com/en-us/nuget/api/package-publish-resource#multipart-form-data
+                uploadStream = Request.Form.Files[0].OpenReadStream();
+            }
+            else
+            {
+                // old clients
+                uploadStream = Request.Body;
+            }
+            if (uploadStream == null)
+            {
+                _log.LogWarning("package upload did not contain multipart/form-data or body");
+                HttpContext.Response.StatusCode = 400;
+                return;
+            }
+
+            try
+            {
+                string apiKey = Request.Headers[apiKeyHeader];
+                if (!await _authentication.AuthenticateAsync(apiKey))
+                {
+                    HttpContext.Response.StatusCode = 401;
+                    return;
+                }
+
+                var result = await _indexer.IndexAsync(uploadStream, ct);
+
+                switch (result)
+                {
+                    case PackageIndexingResult.InvalidPackage:
+                        HttpContext.Response.StatusCode = 400;
+                        break;
+
+                    case PackageIndexingResult.PackageAlreadyExists:
+                        HttpContext.Response.StatusCode = 409;
+                        break;
+
+                    case PackageIndexingResult.Success:
+                        HttpContext.Response.StatusCode = 201;
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.LogError(e, "Exception thrown during package upload");
+            }
+            finally
+            {
+                uploadStream.Dispose();
+            }
+        }
+
+        public async Task PostPackage(string id, string version)
+        {
+            if (!NuGetVersion.TryParse(version, out var nugetVersion))
+            {
+                HttpContext.Response.StatusCode = 400;
+            }
+
+            string apiKey = HttpContext.Request.Headers[apiKeyHeader];
+            if (!await _authentication.AuthenticateAsync(apiKey))
+            {
+                HttpContext.Response.StatusCode = 403;
+            }
+
+            if (await _packages.RelistPackageAsync(id, nugetVersion))
+            {
+                HttpContext.Response.StatusCode = 200;
+            }
+            else
+            {
+                HttpContext.Response.StatusCode = 404;
+            }
+        }
+
+        public async Task DeletePackage(string id, string version)
+        {
+            if (!NuGetVersion.TryParse(version, out var nugetVersion))
+            {
+                HttpContext.Response.StatusCode = 400;
+            }
+            await _deletion.TryDeletePackageAsync(id, nugetVersion, CancellationToken.None);
+        }
+
+        private FileStreamResult ToODataStream(Package package)
+        {
+            var odataPackage = new ODataResponse<PackageWithUrls>(GetServiceUrl(Request), ToPackageWithUrls(Request, package));
+            var ms = new MemoryStream();
+            _serializer.Serialize(
+                ms,
+                odataPackage.Entity.Pkg,
+                odataPackage.ServiceBaseUrl,
+                odataPackage.Entity.ResourceIdUrl,
+                odataPackage.Entity.PackageContentUrl);
+            ms.Seek(0, SeekOrigin.Begin);
+            return File(ms, atomXmlContentType);
+        }
+
+        private PackageWithUrls ToPackageWithUrls(HttpRequest request, Package pkg)
+        {
+            var serviceUrl = GetServiceUrl(request);
+            var id = pkg.Id;
+            var version = pkg.Version;
+            PackageWithUrls urls = new PackageWithUrls(pkg,
+                $"{serviceUrl}/Packages(Id='{id}',Version='{pkg.Version}')",
+                $"{serviceUrl}/contents/{id.ToLowerInvariant()}/{version.ToNormalizedString()}");
+            return urls;
+        }
+
+        private string GetServiceUrl(HttpRequest request)
+        {
+            var builder = new UriBuilder();
+            builder.Scheme = request.Scheme;
+            builder.Host = request.Host.Host;
+            builder.Port = request.Host.Port ?? 80;
+            builder.Path = basePath;
+            return builder.Uri.ToString();
+        }
+
+        public static Uri GetUri(HttpRequest request)
+        {
+            var builder = new UriBuilder();
+            builder.Scheme = request.Scheme;
+            builder.Host = request.Host.Host;
+            builder.Port = request.Host.Port ?? 80;
+            builder.Path = request.Path;
+            builder.Query = request.QueryString.ToUriComponent();
+            return builder.Uri;
+        }
+    }
+}
+

--- a/src/BaGet/Extensions/IRouteBuilderExtensions.cs
+++ b/src/BaGet/Extensions/IRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
 
@@ -104,6 +104,67 @@ namespace BaGet.Extensions
                 name: Routes.PackageDownloadReadmeRouteName,
                 template: "v3/package/{id}/{version}/readme",
                 defaults: new { controller = "Package", action = "DownloadReadme" });
+
+            return routes;
+        }
+
+        public static IRouteBuilder MapApiV2Routes(this IRouteBuilder routes)
+        {
+            routes.MapRoute(
+                name: Routes.IndexRouteName,
+                template: "v2",
+                defaults: new { controller = "PackagesV2", action = "Index" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("GET") });
+
+            routes.MapRoute(
+                name: Routes.IndexRouteName,
+                template: "v2/$metadata",
+                defaults: new { controller = "PackagesV2", action = "Index" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("GET") });
+
+            routes.MapRoute(
+                name: Routes.UploadPackageRouteName,
+                template: "v2",
+                defaults: new { controller = "PackagesV2", action = "PutPackage" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("PUT") });
+
+            routes.MapRoute(
+                name: Routes.PackageDownloadRouteName,
+                template: "v2/contents/{id}/{version}",
+                defaults: new { controller = "PackagesV2", action = "DownloadPackage" });
+
+            routes.MapRoute(
+                name: Routes.PackageDownloadRouteName,
+                template: "v2/Packages(Id='{id}',Version='{version}')",
+                defaults: new { controller = "PackagesV2", action = "DownloadPackage" });
+
+            routes.MapRoute(
+                name: Routes.SearchRouteName,
+                template: "v2/FindPackagesById",
+                defaults: new { controller = "PackagesV2", action = "FindPackagesById" });
+
+            routes.MapRoute(
+                name: Routes.SearchRouteName,
+                template: "v2/Packages()",
+                defaults: new { controller = "PackagesV2", action = "QueryPackages" });
+
+            routes.MapRoute(
+                name: Routes.UploadPackageRouteName,
+                template: "v2/package",
+                defaults: new { controller = "PackagesV2", action = "PutPackage" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("PUT") });
+
+            routes.MapRoute(
+                name: Routes.RelistRouteName,
+                template: "v2/package/{id}/{version}",
+                defaults: new { controller = "PackagesV2", action = "PostPackage" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("POST") });
+
+            routes.MapRoute(
+                name: Routes.DeleteRouteName,
+                template: "v2/package/{id}/{version}",
+                defaults: new { controller = "PackagesV2", action = "DeletePackage" },
+                constraints: new { httpMethod = new HttpMethodRouteConstraint("DELETE") });
 
             return routes;
         }

--- a/src/BaGet/Legacy/IODataPackageSerializer.cs
+++ b/src/BaGet/Legacy/IODataPackageSerializer.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace BaGet.Legacy
+{
+    public interface IODataPackageSerializer
+    {
+        void Serialize(Stream outputStream, ODataPackage package, string serviceBaseUrl, string resourceIdUrl, string packageContentUrl);
+
+        void Serialize(Stream outputStream, IEnumerable<PackageWithUrls> package, string serviceBaseUrl);
+    }
+}

--- a/src/BaGet/Legacy/NuGetWebApiODataModelBuilder.cs
+++ b/src/BaGet/Legacy/NuGetWebApiODataModelBuilder.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.OData.Edm;
+
+namespace BaGet.Legacy
+{
+    public class NuGetWebApiODataModelBuilder
+    {
+        private IEdmModel _model;
+
+        public IEdmModel Model
+        {
+            get
+            {
+                if (_model == null)
+                {
+                    throw new InvalidOperationException("Must invoke Build method before accessing Model.");
+                }
+                return _model;
+            }
+        }
+
+        public void Build()
+        {
+            var builder = new ODataConventionModelBuilder();
+
+            var entity = builder.EntitySet<ODataPackage>("Packages");
+            entity.EntityType.HasKey(pkg => pkg.Id);
+            entity.EntityType.HasKey(pkg => pkg.Version);
+
+            var searchAction = builder.Action("Search");
+            searchAction.Parameter<string>("searchTerm");
+            searchAction.Parameter<string>("targetFramework");
+            searchAction.Parameter<bool>("includePrerelease");
+            searchAction.ReturnsCollectionFromEntitySet<ODataPackage>("Packages");
+
+            var findPackagesAction = builder.Action("FindPackagesById");
+            findPackagesAction.Parameter<string>("id");
+            findPackagesAction.ReturnsCollectionFromEntitySet<ODataPackage>("Packages");
+
+            var getUpdatesAction = builder.Action("GetUpdates");
+            getUpdatesAction.Parameter<string>("packageIds");
+            getUpdatesAction.Parameter<bool>("includePrerelease");
+            getUpdatesAction.Parameter<bool>("includeAllVersions");
+            getUpdatesAction.Parameter<string>("targetFrameworks");
+            getUpdatesAction.Parameter<string>("versionConstraints");
+            getUpdatesAction.ReturnsCollectionFromEntitySet<ODataPackage>("Packages");
+
+            _model = builder.GetEdmModel();
+        }
+    }
+}

--- a/src/BaGet/Legacy/ODataPackage.cs
+++ b/src/BaGet/Legacy/ODataPackage.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using BaGet.Core.Entities;
+
+namespace BaGet.Legacy
+{
+    public class ODataPackage : IEquatable<ODataPackage>
+    {
+        public ODataPackage() { }
+
+        public ODataPackage(Package package)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (package.Version == null)
+                throw new ArgumentException("server package version is null");
+            Version = package.Version.OriginalVersion;
+            NormalizedVersion = package.Version.ToNormalizedString();
+
+            Authors = package.Authors == null ? null : string.Join(",", package.Authors);
+            IconUrl = package.IconUrl?.AbsoluteUri;
+            LicenseUrl = package.LicenseUrl?.AbsoluteUri;
+            ProjectUrl = package.ProjectUrl?.AbsoluteUri;
+            Dependencies = ToDependenciesString(package.Dependencies);
+
+            Id = package.Id;
+            Title = package.Title;
+            RequireLicenseAcceptance = package.RequireLicenseAcceptance;
+            Description = package.Description;
+            Summary = package.Summary;
+            Language = package.Language;
+            Tags = package.Tags == null ? null : string.Join(",", package.Tags);
+            //PackageHashAlgorithm = package.PackageHashAlgorithm;
+            //LastUpdated = package.LastUpdated.UtcDateTime;
+            Published = package.Published;
+            // IsAbsoluteLatestVersion = package.IsAbsoluteLatestVersion;
+            // IsLatestVersion = package.IsLatestVersion;
+            // IsPrerelease = !package.IsReleaseVersion();
+            Listed = package.Listed;
+            DownloadCount = (int)package.Downloads;
+            if (package.MinClientVersion != null)
+                MinClientVersion = package.MinClientVersion;
+
+            //PackageSize = package.PackageSize;
+            //Created = package.Created.UtcDateTime;
+            //VersionDownloadCount = package.VersionDownloadCount;
+        }
+
+        public string Id { get; set; }
+
+        public string Version { get; set; }
+
+        public string NormalizedVersion { get; set; }
+
+        public bool IsPrerelease { get; set; }
+
+        public string Title { get; set; }
+
+        public string Authors { get; set; }
+
+        public string Owners { get; set; }
+
+        public string IconUrl { get; set; }
+
+        public string LicenseUrl { get; set; }
+
+        public string ProjectUrl { get; set; }
+
+        public int DownloadCount { get; set; }
+
+        public bool RequireLicenseAcceptance { get; set; }
+
+        public bool DevelopmentDependency { get; set; }
+
+        public string Description { get; set; }
+
+        public string Summary { get; set; }
+
+        public string ReleaseNotes { get; set; }
+
+        public DateTime Published { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+
+        public string Dependencies { get; set; }
+
+        public string PackageHash { get; set; }
+
+        public string PackageHashAlgorithm { get; set; }
+
+        public int PackageSize { get; set; }
+
+        public string Copyright { get; set; }
+
+        public string Tags { get; set; }
+
+        public bool IsAbsoluteLatestVersion { get; set; }
+
+        public bool IsLatestVersion { get; set; }
+
+        public bool Listed { get; set; }
+
+        public int VersionDownloadCount { get; set; }
+
+        public string MinClientVersion { get; set; }
+
+        public string Language { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1}", Id, Version);
+        }
+
+        public bool Equals(ODataPackage other)
+        {
+            if (ReferenceEquals(other, null)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Equals(Id, other.Id) && Equals(Version, other.Version);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ODataPackage);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode() * 5432 + Version.GetHashCode() * 754;
+        }
+
+        private static string ToDependenciesString(IEnumerable<PackageDependency> dependencies)
+        {
+            if (dependencies == null || !dependencies.Any())
+                return null;
+
+            var texts = new List<string>();
+            var frameworkDeps = dependencies.Where(IsFrameworkDependency).Select(d => d.TargetFramework).Distinct();
+            foreach (var frameworkDep in frameworkDeps)
+            {
+                texts.Add(string.Format(CultureInfo.InvariantCulture, "{0}:{1}:{2}", null, null, frameworkDep));
+            }
+            foreach (var packageDependency in dependencies.Where(d => !IsFrameworkDependency(d)))
+            {
+                texts.Add(string.Format(CultureInfo.InvariantCulture, "{0}:{1}:{2}",
+                    packageDependency.Id,
+                    packageDependency.VersionRange == null ? null : packageDependency.VersionRange,
+                    packageDependency.TargetFramework));
+            }
+
+            return string.Join("|", texts);
+        }
+
+        private static bool IsFrameworkDependency(PackageDependency dependency)
+        {
+            return dependency.Id == null && dependency.VersionRange == null;
+        }
+    }
+}

--- a/src/BaGet/Legacy/ODataPackageSerializer.cs
+++ b/src/BaGet/Legacy/ODataPackageSerializer.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace BaGet.Legacy
+{
+    public class ODataPackageSerializer : IODataPackageSerializer
+    {
+        public void Serialize(Stream outputStream, ODataPackage package, string serviceBaseUrl, string resourceIdUrl, string packageContentUrl)
+        {
+            var doc = new XElement(XmlElements.entry,
+                new XAttribute(XmlElements.baze, XNamespace.Get(serviceBaseUrl)),
+                new XAttribute(XmlElements.m, XmlNamespaces.m),
+                new XAttribute(XmlElements.d, XmlNamespaces.d),
+                new XAttribute(XmlElements.georss, XmlNamespaces.georss),
+                new XAttribute(XmlElements.gml, XmlNamespaces.gml),
+                new XElement(XmlElements.id, resourceIdUrl),
+                new XElement(XmlElements.title, package.Title),
+                new XElement(XmlElements.author, new XElement(XmlElements.name, package.Authors)),
+                new XElement(
+                    XmlElements.content,
+                    new XAttribute("type", "application/zip"),
+                    new XAttribute("src", packageContentUrl)
+                ),
+                GetProperties(package)
+            );
+            var writer = XmlWriter.Create(outputStream);
+            doc.WriteTo(writer);
+            writer.Flush();
+        }
+
+        private static XElement GetProperties(ODataPackage package)
+        {
+            return new XElement(
+                                XmlElements.m_properties,
+                                new XElement(XmlElements.d_Id, package.Id),
+                                new XElement(XmlElements.d_Title, package.Title),
+                                new XElement(XmlElements.d_Version, package.Version),
+                                new XElement(XmlElements.d_NormalizedVersion, package.NormalizedVersion),
+                                new XElement(XmlElements.d_Authors, package.Authors),
+                                new XElement(XmlElements.d_Copyright, package.Copyright),
+                                new XElement(XmlElements.d_Dependencies, package.Dependencies),
+                                new XElement(XmlElements.d_Description, package.Description),
+                                new XElement(XmlElements.d_DownloadCount, package.DownloadCount), //TODO m:type="Edm.Int32"
+                                new XElement(XmlElements.d_LastEdited, package.LastUpdated),
+                                new XElement(XmlElements.d_Published, package.Published),
+                                new XElement(XmlElements.d_PackageHash, package.PackageHash),
+                                new XElement(XmlElements.d_PackageHashAlgorithm, package.PackageHashAlgorithm),
+                                new XElement(XmlElements.d_PackageSize, package.PackageSize),
+                                new XElement(XmlElements.d_ProjectUrl, package.ProjectUrl),
+                                new XElement(XmlElements.d_IconUrl, package.IconUrl),
+                                new XElement(XmlElements.d_LicenseUrl, package.LicenseUrl),
+                                //new XElement(XmlElements.d_ReportAbuseUrl, package.ReportAbuseUrl),
+                                new XElement(XmlElements.d_Tags, package.Tags),
+                                new XElement(XmlElements.d_RequireLicenseAcceptance, package.RequireLicenseAcceptance)
+                            );
+        }
+
+        public void Serialize(Stream outputStream, IEnumerable<PackageWithUrls> packages, string serviceBaseUrl)
+        {
+            var list = packages.ToList();
+            var doc = new XElement(
+                XmlElements.feed,
+                new XAttribute(XmlElements.baze, XNamespace.Get(serviceBaseUrl)),
+                new XAttribute(XmlElements.m, XmlNamespaces.m),
+                new XAttribute(XmlElements.d, XmlNamespaces.d),
+                new XAttribute(XmlElements.georss, XmlNamespaces.georss),
+                new XAttribute(XmlElements.gml, XmlNamespaces.gml),
+                new XElement(XmlElements.m_count, list.Count),
+                list.Select(x =>
+                    new XElement(
+                        XmlElements.entry,
+                        new XElement(XmlElements.id, x.ResourceIdUrl),
+                        new XElement(XmlElements.title, x.Pkg.Title),
+                        new XElement(XmlElements.author, new XElement(XmlElements.name, x.Pkg.Authors)),
+                        new XElement(
+                            XmlElements.content,
+                            new XAttribute("type", "application/zip"),
+                            new XAttribute("src", x.PackageContentUrl)
+                        ),
+                        GetProperties(x.Pkg)
+                    )
+                )
+            );
+            var writer = XmlWriter.Create(outputStream);
+            doc.WriteTo(writer);
+            writer.Flush();
+        }
+    }
+}

--- a/src/BaGet/Legacy/ODataResponse.cs
+++ b/src/BaGet/Legacy/ODataResponse.cs
@@ -1,0 +1,18 @@
+namespace BaGet.Legacy
+{
+    public class ODataResponse<T>
+    {
+        private readonly string _serviceBaseUrl;
+        private readonly T _entity;
+
+        public ODataResponse(string serviceBaseUrl, T entity)
+        {
+            _serviceBaseUrl = serviceBaseUrl;
+            _entity = entity;
+        }
+
+        public string ServiceBaseUrl => _serviceBaseUrl;
+
+        public T Entity => _entity;
+    }
+}

--- a/src/BaGet/Legacy/PackageWithUrls.cs
+++ b/src/BaGet/Legacy/PackageWithUrls.cs
@@ -1,0 +1,31 @@
+using BaGet.Core.Entities;
+
+namespace BaGet.Legacy
+{
+    public class PackageWithUrls
+    {
+        private readonly string resourceIdUrl;
+        private readonly string packageContentUrl;
+        private readonly ODataPackage pkg;
+
+        public PackageWithUrls(ODataPackage pkg, string resourceIdUrl, string packageContentUrl)
+        {
+            this.pkg = pkg;
+            this.resourceIdUrl = resourceIdUrl;
+            this.packageContentUrl = packageContentUrl;
+        }
+
+        public PackageWithUrls(Package pkg, string resourceIdUrl, string packageContentUrl)
+        {
+            this.pkg = new ODataPackage(pkg);
+            this.resourceIdUrl = resourceIdUrl;
+            this.packageContentUrl = packageContentUrl;
+        }
+
+        public string ResourceIdUrl => resourceIdUrl;
+
+        public string PackageContentUrl => packageContentUrl;
+
+        public ODataPackage Pkg => pkg;
+    }
+}

--- a/src/BaGet/Legacy/XmlElements.cs
+++ b/src/BaGet/Legacy/XmlElements.cs
@@ -1,0 +1,48 @@
+using System.Xml.Linq;
+
+namespace BaGet.Legacy
+{
+    public static class XmlElements
+    {
+        public static readonly XName feed = XmlNamespaces.xmlns + "feed";
+        public static readonly XName entry = XmlNamespaces.xmlns + "entry";
+        public static readonly XName title = XmlNamespaces.xmlns + "title";
+        public static readonly XName author = XmlNamespaces.xmlns + "author";
+        public static readonly XName name = XmlNamespaces.xmlns + "name";
+        public static readonly XName link = XmlNamespaces.xmlns + "link";
+        public static readonly XName id = XmlNamespaces.xmlns + "id";
+        public static readonly XName content = XmlNamespaces.xmlns + "content";
+
+        public static readonly XName m_count = XmlNamespaces.m + "count";
+        public static readonly XName m_properties = XmlNamespaces.m + "properties";
+
+        public static readonly XName d_Id = XmlNamespaces.d + "Id";
+        public static readonly XName d_Title = XmlNamespaces.d + "Title";
+        public static readonly XName d_Version = XmlNamespaces.d + "Version";
+        public static readonly XName d_NormalizedVersion = XmlNamespaces.d + "NormalizedVersion";
+        public static readonly XName d_Authors = XmlNamespaces.d + "Authors";
+        public static readonly XName d_Copyright = XmlNamespaces.d + "Copyright";
+        public static readonly XName d_Dependencies = XmlNamespaces.d + "Dependencies";
+        public static readonly XName d_Description = XmlNamespaces.d + "Description";
+        public static readonly XName d_IconUrl = XmlNamespaces.d + "IconUrl";
+        public static readonly XName d_LicenseUrl = XmlNamespaces.d + "LicenseUrl";
+        public static readonly XName d_ProjectUrl = XmlNamespaces.d + "ProjectUrl";
+        public static readonly XName d_Tags = XmlNamespaces.d + "Tags";
+        public static readonly XName d_ReportAbuseUrl = XmlNamespaces.d + "ReportAbuseUrl";
+        public static readonly XName d_RequireLicenseAcceptance = XmlNamespaces.d + "RequireLicenseAcceptance";
+        public static readonly XName d_DownloadCount = XmlNamespaces.d + "DownloadCount";
+        public static readonly XName d_Created = XmlNamespaces.d + "Created";
+        public static readonly XName d_LastEdited = XmlNamespaces.d + "LastEdited";
+        public static readonly XName d_Published = XmlNamespaces.d + "Published";
+        public static readonly XName d_PackageHash = XmlNamespaces.d + "PackageHash";
+        public static readonly XName d_PackageHashAlgorithm = XmlNamespaces.d + "PackageHashAlgorithm";
+        public static readonly XName d_MinClientVersion = XmlNamespaces.d + "MinClientVersion";
+        public static readonly XName d_PackageSize = XmlNamespaces.d + "PackageSize";
+
+        public static readonly XName baze = XNamespace.Xmlns + "base";
+        public static readonly XName m = XNamespace.Xmlns + "m";
+        public static readonly XName d = XNamespace.Xmlns + "d";
+        public static readonly XName georss = XNamespace.Xmlns + "georss";
+        public static readonly XName gml = XNamespace.Xmlns + "gml";
+    }
+}

--- a/src/BaGet/Legacy/XmlNamespaces.cs
+++ b/src/BaGet/Legacy/XmlNamespaces.cs
@@ -1,0 +1,14 @@
+using System.Xml.Linq;
+
+namespace BaGet.Legacy
+{
+    public static class XmlNamespaces
+    {
+        public static readonly XNamespace xmlns = "http://www.w3.org/2005/Atom";
+        //public static readonly XNamespace baze = "https://www.nuget.org/api/v2/curated-feeds/microsoftdotnet";
+        public static readonly XNamespace m = "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata";
+        public static readonly XNamespace d = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+        public static readonly XNamespace georss = "http://www.georss.org/georss";
+        public static readonly XNamespace gml = "http://www.opengis.net/gml";
+    }
+}

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BaGet.Configurations;
 using BaGet.Core.Configuration;
 using BaGet.Core.Entities;
@@ -68,7 +68,8 @@ namespace BaGet
                     .MapSymbolRoutes()
                     .MapSearchRoutes()
                     .MapRegistrationRoutes()
-                    .MapPackageContentRoutes();
+                    .MapPackageContentRoutes()
+                    .MapApiV2Routes();
             });
 
             app.UseSpa(spa =>


### PR DESCRIPTION
### What does this PR do?

Support for [Chocolatey](https://chocolatey.org/).
This includes rudimentary support for api v2 and OData.
Lifted a lot of the core logic from https://github.com/ai-traders/BaGet.
Created Legacy namespace and tried to keep everything contained, would prefer if Choco added nuget api v3 support.

### Closes Issue(s)

#43 

At least partially, OData queries can be very expressive, I dont know to what extent old nuget clients use it.

### Motivation

Need it, and want to reuse the same server software between nuget and choco.

### Additional Notes

Would like some help in structuring this in a better way, support for api v2 got added but code became more complex. Not sure if its worth the cost. But the lack of support turned out to be a deal breaker for us.