### PR TITLE
Take advantage of docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ WORKDIR /app
 EXPOSE 80
 
 FROM microsoft/dotnet:2.2-sdk AS build
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
 WORKDIR /src
 COPY /src .
 RUN dotnet restore BaGet
 RUN dotnet build BaGet -c Release -o /app
 
 FROM build AS publish
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
 RUN dotnet publish BaGet -c Release -o /app
 
 FROM base AS final


### PR DESCRIPTION
By moving these two RUNs above COPY . ., docker will be able to cache the installation of nodejs and speed up builds.