### PR TITLE
Add support for HTTPS #227

### DIFF
--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -43,5 +43,7 @@ namespace BaGet.Core.Configuration
 
         [Required]
         public MirrorOptions Mirror { get; set; }
+        
+        public HttpsOptions Https { get; set; }
     }
 }

--- a/src/BaGet.Core/Configuration/HttpsOptions.cs
+++ b/src/BaGet.Core/Configuration/HttpsOptions.cs
@@ -1,0 +1,11 @@
+namespace BaGet.Core.Configuration
+{
+    public class HttpsOptions
+    {
+        public int Port { get; set; }
+
+        public string CertificateFileName { get; set; }
+
+        public string CertificatePassword { get; set; }
+    }
+}

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using BaGet.Core.Mirror;
 using BaGet.Extensions;
 using McMaster.Extensions.CommandLineUtils;
@@ -53,6 +54,11 @@ namespace BaGet
                     // Remove the upload limit from Kestrel. If needed, an upload limit can
                     // be enforced by a reverse proxy server, like IIS.
                     options.Limits.MaxRequestBodySize = null;
+
+                    if (Startup.UseHttps)
+                    {
+                        Startup.KestrelServerOptions = options;
+                    }
                 })
                 .ConfigureAppConfiguration((builderContext, config) =>
                 {

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "ApiKey": "",
+  "ApiKey": "SGD1953",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
 
@@ -21,6 +21,12 @@
     "Enabled": false,
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
+
+  //"Https": {
+  //  "Port":  5001, 
+  //  "CertificateFileName": "MyCertificate.pfx",
+  //  "CertificatePassword": "MySecretPassword"
+  //},
 
   "Logging": {
     "IncludeScopes": false,

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "ApiKey": "SGD1953",
+  "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
 


### PR DESCRIPTION
Allows to use Kestrel with HTTPS even without a Reverse Proxy (e. g. for development or internal purposes).

Addresses https://github.com/loic-sharma/BaGet/issues/227

See https://github.com/loic-sharma/BaGet/issues/227

Summary of the changes (in less than 80 chars)

 * Kestrel configuration was modified so that it can use HTTPS if configured.
