### PR TITLE
Private feeds part 3

### DIFF
--- a/src/BaGet.Core.Server/Configuration/ConfigureMvcOptions.cs
+++ b/src/BaGet.Core.Server/Configuration/ConfigureMvcOptions.cs
@@ -1,0 +1,26 @@
+using BaGet.Core.Configuration;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace BaGet.Configuration
+{
+    public class ConfigureMvcOptions : IConfigureOptions<MvcOptions>
+    {
+        private readonly BaGetOptions _options;
+
+        public ConfigureMvcOptions(IOptions<BaGetOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public void Configure(MvcOptions options)
+        {
+            // Allow the configuration to disable authentication.
+            if (_options.FeedAuthentication.Type == AuthenticationType.None)
+            {
+                options.Filters.Add(new AllowAnonymousFilter());
+            }
+        }
+    }
+}

--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -48,5 +48,20 @@ namespace BaGet.Core.Configuration
 
         [Required]
         public MirrorOptions Mirror { get; set; }
+
+        [Required] //Required but WITH Default value => section can be missing inside appsettings for older configurations without feed authentication
+        public FeedAuthenticationOptions FeedAuthentication { get; set; } = new FeedAuthenticationOptions() { Type = AuthenticationType.None };
+
+        /// <summary>
+        /// if enabled "Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII" is set to true, means the tracing shows some (security) critical information
+        /// should be used ONLY for debugging Security (private feeds)
+        /// </summary>
+        public bool ShowPII { get; set; } = false;
+
+        /// <summary>
+        /// Middleware for "Basic" to "Bearer" translation is added 
+        /// </summary>
+        public bool AddTokenMiddleware { get; set; } = false;
+
     }
 }

--- a/src/BaGet.Core/Configuration/BasicAuthenticationOptions.cs
+++ b/src/BaGet.Core/Configuration/BasicAuthenticationOptions.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace BaGet.Core.Configuration
+{
+    public class BasicCredential
+    {
+        public string UserName { get; set; }
+
+        public string Password { get; set; }
+
+        public string Domain { get; set; }
+
+    }
+
+    public class BasicAuthenticationOptions 
+    {
+        public List<BasicCredential>AllowedUsers { get; set; }
+    }
+
+}

--- a/src/BaGet.Core/Configuration/FeedAuthenticationOptions.cs
+++ b/src/BaGet.Core/Configuration/FeedAuthenticationOptions.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace BaGet.Core.Configuration
+{
+    public enum AuthenticationType
+    {
+        None,
+        Basic,
+        JwtBearer,
+        AzureActiveDirectory, //AAD is JwtBearer but with more and complex settings!
+    }
+       
+
+    public class FeedAuthenticationOptions : IValidatableObject
+    {
+        public AuthenticationType Type { get; set; }
+        public string SettingsKey { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Type !=AuthenticationType.None && string.IsNullOrEmpty(SettingsKey))
+            {
+                yield return new ValidationResult(
+                    $"The {nameof(SettingsKey)} configuration is required if authentication is enabled",
+                    new[] { nameof(SettingsKey) });
+            }
+        }
+    }
+}

--- a/src/BaGet.Core/Services/IUserValidationService.cs
+++ b/src/BaGet.Core/Services/IUserValidationService.cs
@@ -1,0 +1,10 @@
+using System.Net;
+using System.Threading.Tasks;
+
+namespace BaGet.Core.Services
+{
+    public interface IUserValidationService
+    {
+        Task<bool> IsValidUserAsync(NetworkCredential credential);
+    }
+}


### PR DESCRIPTION
- a few extensions to appsettings.json for auth
    - new properties should have defaults (not active)

- a few base classes needed for basic auth
   - MVCFilter not activated in code => no risk now


to review: 
- namespaces and locations
- appsettings.json => how we "design" authentication settings....=> FeedAuthenticationOptions
(
