### PR TITLE
Allow a way to filter packages in DatabaseSearchService

### DIFF
--- a/src/BaGet.Core/Search/DatabaseSearchService.cs
+++ b/src/BaGet.Core/Search/DatabaseSearchService.cs
@@ -34,6 +34,8 @@ namespace BaGet.Core.Search
             var frameworks = GetCompatibleFrameworks(framework);
             var packages = await SearchImplAsync(query, skip, take, includePrerelease, includeSemVer2, packageType, frameworks);
 
+            packages = FilterPackages(packages);
+
             foreach (var package in packages)
             {
                 var versions = package.OrderByDescending(p => p.Version).ToList();
@@ -59,6 +61,11 @@ namespace BaGet.Core.Search
             }
 
             return result.AsReadOnly();
+        }
+
+        protected virtual List<IGrouping<string, Package>> FilterPackages(List<IGrouping<string, Package>> packages)
+        {
+            return packages;
         }
 
         private IReadOnlyList<string> GetCompatibleFrameworks(string framework)

--- a/src/BaGet.Core/State/PackageService.cs
+++ b/src/BaGet.Core/State/PackageService.cs
@@ -17,7 +17,7 @@ namespace BaGet.Core.State
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public virtual async Task<PackageAddResult> AddAsync(Package package)
+        public async Task<PackageAddResult> AddAsync(Package package)
         {
             try
             {
@@ -34,7 +34,7 @@ namespace BaGet.Core.State
             }
         }
 
-        public virtual Task<bool> ExistsAsync(string id, NuGetVersion version = null)
+        public Task<bool> ExistsAsync(string id, NuGetVersion version = null)
         {
             var query = _context.Packages.Where(p => p.Id == id);
 
@@ -46,7 +46,7 @@ namespace BaGet.Core.State
             return query.AnyAsync();
         }
 
-        public virtual async Task<IReadOnlyList<Package>> FindAsync(string id, bool includeUnlisted = false)
+        public async Task<IReadOnlyList<Package>> FindAsync(string id, bool includeUnlisted = false)
         {
             var query = _context.Packages
                 .Include(p => p.Dependencies)
@@ -62,7 +62,7 @@ namespace BaGet.Core.State
             return (await query.ToListAsync()).AsReadOnly();
         }
 
-        public virtual Task<Package> FindOrNullAsync(string id, NuGetVersion version, bool includeUnlisted = false)
+        public Task<Package> FindOrNullAsync(string id, NuGetVersion version, bool includeUnlisted = false)
         {
             var query = _context.Packages
                 .Include(p => p.Dependencies)
@@ -78,22 +78,22 @@ namespace BaGet.Core.State
             return query.FirstOrDefaultAsync();
         }
 
-        public virtual Task<bool> UnlistPackageAsync(string id, NuGetVersion version)
+        public Task<bool> UnlistPackageAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Listed = false);
         }
 
-        public virtual Task<bool> RelistPackageAsync(string id, NuGetVersion version)
+        public Task<bool> RelistPackageAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Listed = true);
         }
 
-        public virtual Task<bool> AddDownloadAsync(string id, NuGetVersion version)
+        public Task<bool> AddDownloadAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Downloads += 1);
         }
 
-        public virtual async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version)
+        public async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version)
         {
             var package = await _context.Packages
                 .Where(p => p.Id == id)
@@ -113,7 +113,7 @@ namespace BaGet.Core.State
             return true;
         }
 
-        protected virtual async Task<bool> TryUpdatePackageAsync(string id, NuGetVersion version, Action<Package> action)
+        private async Task<bool> TryUpdatePackageAsync(string id, NuGetVersion version, Action<Package> action)
         {
             var package = await _context.Packages
                 .Where(p => p.Id == id)

--- a/src/BaGet.Core/State/PackageService.cs
+++ b/src/BaGet.Core/State/PackageService.cs
@@ -17,7 +17,7 @@ namespace BaGet.Core.State
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public async Task<PackageAddResult> AddAsync(Package package)
+        public virtual async Task<PackageAddResult> AddAsync(Package package)
         {
             try
             {
@@ -34,7 +34,7 @@ namespace BaGet.Core.State
             }
         }
 
-        public Task<bool> ExistsAsync(string id, NuGetVersion version = null)
+        public virtual Task<bool> ExistsAsync(string id, NuGetVersion version = null)
         {
             var query = _context.Packages.Where(p => p.Id == id);
 
@@ -46,7 +46,7 @@ namespace BaGet.Core.State
             return query.AnyAsync();
         }
 
-        public async Task<IReadOnlyList<Package>> FindAsync(string id, bool includeUnlisted = false)
+        public virtual async Task<IReadOnlyList<Package>> FindAsync(string id, bool includeUnlisted = false)
         {
             var query = _context.Packages
                 .Include(p => p.Dependencies)
@@ -62,7 +62,7 @@ namespace BaGet.Core.State
             return (await query.ToListAsync()).AsReadOnly();
         }
 
-        public Task<Package> FindOrNullAsync(string id, NuGetVersion version, bool includeUnlisted = false)
+        public virtual Task<Package> FindOrNullAsync(string id, NuGetVersion version, bool includeUnlisted = false)
         {
             var query = _context.Packages
                 .Include(p => p.Dependencies)
@@ -78,22 +78,22 @@ namespace BaGet.Core.State
             return query.FirstOrDefaultAsync();
         }
 
-        public Task<bool> UnlistPackageAsync(string id, NuGetVersion version)
+        public virtual Task<bool> UnlistPackageAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Listed = false);
         }
 
-        public Task<bool> RelistPackageAsync(string id, NuGetVersion version)
+        public virtual Task<bool> RelistPackageAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Listed = true);
         }
 
-        public Task<bool> AddDownloadAsync(string id, NuGetVersion version)
+        public virtual Task<bool> AddDownloadAsync(string id, NuGetVersion version)
         {
             return TryUpdatePackageAsync(id, version, p => p.Downloads += 1);
         }
 
-        public async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version)
+        public virtual async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version)
         {
             var package = await _context.Packages
                 .Where(p => p.Id == id)
@@ -113,7 +113,7 @@ namespace BaGet.Core.State
             return true;
         }
 
-        private async Task<bool> TryUpdatePackageAsync(string id, NuGetVersion version, Action<Package> action)
+        protected virtual async Task<bool> TryUpdatePackageAsync(string id, NuGetVersion version, Action<Package> action)
         {
             var package = await _context.Packages
                 .Where(p => p.Id == id)


### PR DESCRIPTION
In some cases, users might want to filter package search results according to a custom logic. Introducing a virtual method like FilterPackages in DatabaseSearchService.cs can help to do that.