### PR TITLE
Add service url to the aws s3 configuration model

### DIFF
--- a/src/BaGet.AWS/Configuration/S3StorageOptions.cs
+++ b/src/BaGet.AWS/Configuration/S3StorageOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using BaGet.Core.Validation;
 
 namespace BaGet.AWS.Configuration
@@ -11,8 +11,11 @@ namespace BaGet.AWS.Configuration
         [RequiredIf(nameof(AccessKey), null, IsInverted = true)]
         public string SecretKey { get; set; }
 
-        [Required]
+        [RequiredIf(nameof(ServiceUrl), null)]
         public string Region { get; set; }
+
+        [RequiredIf(nameof(Region), null)]
+        public string ServiceUrl { get; set; }
 
         [Required]
         public string Bucket { get; set; }

--- a/src/BaGet.AWS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaGet.AWS/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,10 @@ namespace BaGet.AWS.Extensions
 
                 var config = new AmazonS3Config
                 {
-                    RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region)
+                    RegionEndpoint = (options.Region != null)
+                        ? RegionEndpoint.GetBySystemName(options.Region)
+                        : null,
+                    ServiceURL = options.ServiceUrl
                 };
 
                 if (!string.IsNullOrEmpty(options.AccessKey))


### PR DESCRIPTION
Add the `ServiceURL` to configure a local AWS S3 cloud service.
The model will handle the validation, either `RegionEndpoint` or `ServiceURL` must be set. 

Addresses https://github.com/loic-sharma/BaGet/issues/271
