### PR TITLE
Two additional ways of access in AWS S3

### DIFF
--- a/src/BaGet.AWS/Configuration/S3StorageOptions.cs
+++ b/src/BaGet.AWS/Configuration/S3StorageOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using BaGet.Core.Validation;
 
 namespace BaGet.AWS.Configuration
@@ -18,5 +18,7 @@ namespace BaGet.AWS.Configuration
         public string Bucket { get; set; }
 
         public string Prefix { get; set; }
+
+        public string AssumeRoleArn { get; set; }
     }
 }

--- a/src/BaGet.AWS/Configuration/S3StorageOptions.cs
+++ b/src/BaGet.AWS/Configuration/S3StorageOptions.cs
@@ -19,6 +19,8 @@ namespace BaGet.AWS.Configuration
 
         public string Prefix { get; set; }
 
+        public bool UseInstanceProfile { get; set; }
+
         public string AssumeRoleArn { get; set; }
     }
 }

--- a/src/BaGet.AWS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaGet.AWS/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,12 @@ namespace BaGet.AWS.Extensions
                 {
                     RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region)
                 };
+
+                if (options.UseInstanceProfile)
+                {
+                    var credentials = FallbackCredentialsFactory.GetCredentials();
+                    return new AmazonS3Client(credentials, config);
+                }
                 
                 if (!string.IsNullOrEmpty(options.AssumeRoleArn))
                 {

--- a/src/BaGet.AWS/Helpers/AwsIamHelper.cs
+++ b/src/BaGet.AWS/Helpers/AwsIamHelper.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+
+namespace BaGet.AWS.Helpers
+{
+    public static class AwsIamHelper
+    {
+        public static async Task<AWSCredentials> AssumeRoleAsync(AWSCredentials credentials, string roleArn,
+            string roleSessionName)
+        {
+            var assumedCredentials = new AssumeRoleAWSCredentials(credentials, roleArn, roleSessionName);
+            var immutableCredentials = await credentials.GetCredentialsAsync();
+
+            if (string.IsNullOrWhiteSpace(immutableCredentials.Token))
+            {
+                throw new InvalidOperationException($"Unable to assume role {roleArn}");
+            }
+
+            return assumedCredentials;
+        }
+    }
+}

--- a/tests/BaGet.Protocol.Tests/SearchClientTests.cs
+++ b/tests/BaGet.Protocol.Tests/SearchClientTests.cs
@@ -27,7 +27,7 @@ namespace BaGet.Protocol.Tests
             Assert.True(result.Data.Count > 0);
             Assert.Equal(registrationurl, result.Data[0].RegistrationUrl);
             Assert.Equal("Newtonsoft.Json", result.Data[0].Id);
-            Assert.Equal(new NuGetVersion("12.0.1"), result.Data[0].Version);
+            Assert.Equal(new NuGetVersion("12.0.2"), result.Data[0].Version);
         }
 
         [Fact]


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Added UseInstanceProfile config option, for using fallback credentials (instance profile) in AWS
 * Added AssumeRoleArn config option, for assuming cross account role in AWS
 * Todo: Update documentation, not sure where to do this?

Addresses https://github.com/loic-sharma/BaGet/issues/266
