### PR TITLE
Add regex appsettings to control deletion and overwriting behavior

### DIFF
--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -26,7 +26,7 @@ namespace BaGet.Core.Configuration
         /// </summary>
         public PackageDeletionBehavior PackageDeletionBehavior { get; set; } = PackageDeletionBehavior.Unlist;
 
-        public string HardDeleteMatch { get; set; } = ".*";
+        public string DeleteMatch { get; set; } = ".*";
 
         /// <summary>
         /// If enabled, pushing a package that already exists will replace the

--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -26,6 +26,10 @@ namespace BaGet.Core.Configuration
         /// </summary>
         public PackageDeletionBehavior PackageDeletionBehavior { get; set; } = PackageDeletionBehavior.Unlist;
 
+        /// <summary>
+        /// Packages can only be deleted if the name-version string matches this regex.
+        /// Default value allows everything.
+        /// </summary>
         public string DeleteMatch { get; set; } = ".*";
 
         /// <summary>
@@ -34,6 +38,10 @@ namespace BaGet.Core.Configuration
         /// </summary>
         public bool AllowPackageOverwrites { get; set; } = false;
 
+        /// <summary>
+        /// Packages can only be overwritten if the name-version string matches this regex.
+        /// Default value allows everything.
+        /// </summary>
         public string OverwriteMatch { get; set; } = ".*";
 
         /// <summary>

--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -26,11 +26,15 @@ namespace BaGet.Core.Configuration
         /// </summary>
         public PackageDeletionBehavior PackageDeletionBehavior { get; set; } = PackageDeletionBehavior.Unlist;
 
+        public string HardDeleteMatch { get; set; } = ".*";
+
         /// <summary>
         /// If enabled, pushing a package that already exists will replace the
         /// existing package.
         /// </summary>
         public bool AllowPackageOverwrites { get; set; } = false;
+
+        public string OverwriteMatch { get; set; } = ".*";
 
         /// <summary>
         /// If true, disables package pushing, deleting, and relisting.

--- a/src/BaGet.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGet.Core/Indexing/PackageIndexingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGet.Core.Configuration;
@@ -76,7 +77,7 @@ namespace BaGet.Core.Indexing
             // The package is well-formed. Ensure this is a new package.
             if (await _packages.ExistsAsync(package.Id, package.Version))
             {
-                if (!_options.Value.AllowPackageOverwrites)
+                if (!_options.Value.AllowPackageOverwrites || !new Regex(_options.Value.OverwriteMatch).IsMatch(package.VersionString))
                 {
                     return PackageIndexingResult.PackageAlreadyExists;
                 }

--- a/src/BaGet.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGet.Core/Indexing/PackageIndexingService.cs
@@ -77,7 +77,7 @@ namespace BaGet.Core.Indexing
             // The package is well-formed. Ensure this is a new package.
             if (await _packages.ExistsAsync(package.Id, package.Version))
             {
-                if (!_options.Value.AllowPackageOverwrites || !new Regex(_options.Value.OverwriteMatch).IsMatch(package.VersionString))
+                if (!_options.Value.AllowPackageOverwrites || !new Regex(_options.Value.OverwriteMatch).IsMatch($"{package.Id} {package.VersionString}"))
                 {
                     return PackageIndexingResult.PackageAlreadyExists;
                 }

--- a/src/BaGet.Core/State/PackageDeletionService.cs
+++ b/src/BaGet.Core/State/PackageDeletionService.cs
@@ -31,6 +31,12 @@ namespace BaGet.Core.State
 
         public async Task<bool> TryDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
+            if (!new Regex(_options.DeleteMatch).IsMatch(version.ToNormalizedString()))
+            {
+                _logger.LogWarning($"{_options.PackageDeletionBehavior.ToString()} for package {id} {version} is not allowed because the version does not match {_options.HardDeleteMatch}");
+                return false;
+            }
+
             switch (_options.PackageDeletionBehavior)
             {
                 case PackageDeletionBehavior.Unlist:
@@ -62,12 +68,6 @@ namespace BaGet.Core.State
 
         private async Task<bool> TryHardDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
-            if (!new Regex(_options.HardDeleteMatch).IsMatch(version.ToNormalizedString()))
-            {
-                _logger.LogWarning($"Hard delete for package {id} {version} is not allowed because the version does not match {_options.HardDeleteMatch}");
-                return false;
-            }
-
             _logger.LogInformation(
                 "Hard deleting package {PackageId} {PackageVersion} from the database...",
                 id,

--- a/src/BaGet.Core/State/PackageDeletionService.cs
+++ b/src/BaGet.Core/State/PackageDeletionService.cs
@@ -33,7 +33,7 @@ namespace BaGet.Core.State
         {
             if (!new Regex(_options.DeleteMatch).IsMatch(version.ToNormalizedString()))
             {
-                _logger.LogWarning($"{_options.PackageDeletionBehavior.ToString()} for package {id} {version} is not allowed because the version does not match {_options.HardDeleteMatch}");
+                _logger.LogWarning($"{_options.PackageDeletionBehavior.ToString()} for package {id} {version} is not allowed because the version does not match {_options.DeleteMatch}");
                 return false;
             }
 

--- a/src/BaGet.Core/State/PackageDeletionService.cs
+++ b/src/BaGet.Core/State/PackageDeletionService.cs
@@ -31,9 +31,9 @@ namespace BaGet.Core.State
 
         public async Task<bool> TryDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
-            if (!new Regex(_options.DeleteMatch).IsMatch(version.ToNormalizedString()))
+            if (!new Regex(_options.DeleteMatch).IsMatch($"{id} {version.ToNormalizedString()}"))
             {
-                _logger.LogWarning($"{_options.PackageDeletionBehavior.ToString()} for package {id} {version} is not allowed because the version does not match {_options.DeleteMatch}");
+                _logger.LogWarning($"{_options.PackageDeletionBehavior.ToString()} for package {id} {version} is not allowed because the id and version do not match {_options.DeleteMatch}");
                 return false;
             }
 

--- a/src/BaGet.Core/State/PackageDeletionService.cs
+++ b/src/BaGet.Core/State/PackageDeletionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGet.Core.Configuration;
@@ -61,6 +62,12 @@ namespace BaGet.Core.State
 
         private async Task<bool> TryHardDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
+            if (!new Regex(_options.HardDeleteMatch).IsMatch(version.ToNormalizedString()))
+            {
+                _logger.LogWarning($"Hard delete for package {id} {version} is not allowed because the version does not match {_options.HardDeleteMatch}");
+                return false;
+            }
+
             _logger.LogInformation(
                 "Hard deleting package {PackageId} {PackageVersion} from the database...",
                 id,

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -1,7 +1,9 @@
 {
   "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
+  "HardDeleteMatch": ".*",
   "AllowPackageOverwrites": false,
+  "OverwriteMatch": ".*",
 
   "Database": {
     "Type": "Sqlite",

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
-  "HardDeleteMatch": ".*",
+  "DeleteMatch": ".*",
   "AllowPackageOverwrites": false,
   "OverwriteMatch": ".*",
 


### PR DESCRIPTION
The following 2 appsettings have been added and implemented:
- DeleteMatch: Takes a regex as value. Only packages matching this regex (format: {id} {version}) can be unlisted or deleted (depending on the PackageDeletionBehavior). The default value (.*) matches anything.
- OverwriteMatch: Takes a regex as value. Only packages matching this regex (format: {id} {version}) can be overwritten. This condition will only be evaluated when the AllowPackageOverwrites is set to true . The default value (.*) matches anything.