### PR TITLE
Missing "push" in NuGet push command example

### DIFF
--- a/src/BaGet.UI/src/Upload.tsx
+++ b/src/BaGet.UI/src/Upload.tsx
@@ -93,7 +93,7 @@ class Upload extends React.Component<{}, IUploadState> {
 
       case Tab.NuGet:
         name = "NuGet";
-        content = [`nuget -Source ${this.serviceIndexUrl} package.nupkg`];
+        content = [`nuget push -Source ${this.serviceIndexUrl} package.nupkg`];
         documentationUrl = "https://docs.microsoft.com/en-us/nuget/tools/cli-ref-push";
         break;
 


### PR DESCRIPTION
The command example for NuGet is missing the "push" command.
