### PR TITLE
Update versioning strategy

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -69,7 +69,6 @@ jobs:
 
     - script: dotnet pack --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
       displayName: Pack
-      condition: eq(variables['build.sourcebranch'], 'refs/heads/master')
 
     - task: DotNetCoreCLI@2
       displayName: Publish
@@ -83,4 +82,3 @@ jobs:
       displayName: 'Publish Artifacts'
       inputs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      condition: eq(variables['build.sourcebranch'], 'refs/heads/master')

--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -44,17 +44,6 @@ jobs:
       inputs:
         version: 2.2.100
 
-    - task: DotNetCoreCLI@2
-      displayName: Install versioning tool
-      inputs:
-          command: custom
-          custom: tool
-          arguments: install --tool-path . nbgv
-
-    - script: nbgv cloud
-      displayName: Run versioning tool
-      condition: eq(variables['build.sourcebranch'], 'refs/heads/master')
-
     - task: Npm@1
       displayName: Install frontend dependencies
       inputs:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Product>BaGet</Product>
 
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0-prerelease</PackageVersion>
     <PackageProjectUrl>https://loic-sharma.github.io/BaGet/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,9 +2,12 @@
 
   <PropertyGroup>
     <Product>BaGet</Product>
+
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.2.0-prerelease</PackageVersion>
     <PackageProjectUrl>https://loic-sharma.github.io/BaGet/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>
+
     <RepositoryUrl>https://github.com/loic-sharma/BaGet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -36,10 +39,6 @@
 
   <ItemGroup Condition="$(DOTNET_RUNNING_IN_CONTAINER) == ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(IsPackable) == 'true' AND $(DOTNET_RUNNING_IN_CONTAINER) == ''">
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.105" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Product>BaGet</Product>
 
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.2.0-prerelease</PackageVersion>
     <PackageProjectUrl>https://loic-sharma.github.io/BaGet/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>


### PR DESCRIPTION
This replaces `Nerdbank.GitVersioning` with Azure DevOps queue-time variables for versioning. This is a simpler model that should avoid issues like https://github.com/loic-sharma/BaGet/issues/211 and https://github.com/loic-sharma/BaGet/issues/135.

Part of https://github.com/loic-sharma/BaGet/issues/57