### PR TITLE
Gracefully handle cancelled instant search requests

### DIFF
--- a/src/BaGet.Core.Server/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IApplicationBuilderExtensions.cs
@@ -1,4 +1,3 @@
-
 using System;
 using Microsoft.AspNetCore.Builder;
 

--- a/src/BaGet.Core.Server/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IApplicationBuilderExtensions.cs
@@ -1,0 +1,16 @@
+
+using System;
+using Microsoft.AspNetCore.Builder;
+
+namespace BaGet.Core.Server.Extensions
+{
+    public static class IApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseOperationCancelledMiddleware(this IApplicationBuilder app)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+
+            return app.UseMiddleware<OperationCancelledMiddleware>();
+        }
+    }
+}

--- a/src/BaGet.Core.Server/OperationCancelledMiddleware.cs
+++ b/src/BaGet.Core.Server/OperationCancelledMiddleware.cs
@@ -1,0 +1,62 @@
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace BaGet
+{
+    /// <summary>
+    /// Captures <see cref="OperationCanceledException" /> and converts to HTTP 409 response.
+    /// Based off: https://github.com/aspnet/AspNetCore/blob/28157e62597bf0e043bc7e937e44c5ec81946b83/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+    /// </summary>
+    public class OperationCancelledMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<OperationCancelledMiddleware> _logger;
+
+        public OperationCancelledMiddleware(RequestDelegate next, ILogger<OperationCancelledMiddleware> logger)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception e) when (ShouldHandleException(context, e))
+            {
+                try
+                {
+                    _logger.LogWarning("Request cancelled");
+
+                    context.Response.Clear();
+                    context.Response.StatusCode = (int)HttpStatusCode.Conflict;
+                    return;
+                }
+                catch (Exception)
+                {
+                    // If there's an exception, rethrow the original exception.
+                }
+
+                throw;
+            }
+
+            bool ShouldHandleException(HttpContext ctx, Exception e)
+            {
+                if (ctx.Response.HasStarted) return false;
+
+                if (e is OperationCanceledException) return true;
+                if (e.InnerException is OperationCanceledException) return true;
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/BaGet.Core.Server/OperationCancelledMiddleware.cs
+++ b/src/BaGet.Core.Server/OperationCancelledMiddleware.cs
@@ -1,10 +1,7 @@
-
 using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 
 namespace BaGet

--- a/src/BaGet.UI/src/SearchResults.tsx
+++ b/src/BaGet.UI/src/SearchResults.tsx
@@ -217,8 +217,14 @@ class SearchResults extends React.Component<ISearchResultsProps, ISearchResultsS
     const url = this.buildUrl(query, includePrerelease, packageType, targetFramework);
 
     fetch(url, {signal: this.resultsController.signal}).then(response => {
-      return response.json();
+      return response.ok
+        ? response.json()
+        : null;
     }).then(resultsJson => {
+      if (!resultsJson) {
+        return;
+      }
+
       const results = resultsJson as ISearchResponse;
 
       this.setState({
@@ -226,6 +232,12 @@ class SearchResults extends React.Component<ISearchResultsProps, ISearchResultsS
         items: results.data,
         targetFramework,
       });
+    })
+    .catch((e) => {
+      var ex = e as DOMException;
+      if (!ex || ex.code !== DOMException.ABORT_ERR) {
+        console.log("Unexpected error on search", e);
+      }
     });
   }
 

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using BaGet.Configuration;
 using BaGet.Core;
+using BaGet.Core.Server.Extensions;
 using BaGet.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -58,6 +59,7 @@ namespace BaGet
             app.UseSpaStaticFiles();
 
             app.UseCors(ConfigureCorsOptions.CorsPolicy);
+            app.UseOperationCancelledMiddleware();
 
             app.UseMvc(routes =>
             {


### PR DESCRIPTION
Adds a middleware to swallow cancellation exceptions due to instant searching.
Swallows frontend errors caused by instant searching.

Part of https://github.com/loic-sharma/BaGet/issues/354