### PR TITLE
feat: Add Sentry for aspnetcore

### DIFF
--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.0.0-beta4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -48,6 +48,7 @@ namespace BaGet
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .UseSentry()
                 .UseKestrel(options =>
                 {
                     // Remove the upload limit from Kestrel. If needed, an upload limit can

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -22,6 +22,10 @@
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
 
+  "Sentry": {
+    "Dsn": "https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141"
+  },
+
   "Logging": {
     "IncludeScopes": false,
     "Debug": {


### PR DESCRIPTION
Added the [Sentry](github.com/getsentry/sentry) SDK [for .NET](https://github.com/getsentry/sentry-dotnet).

I've added a DSN to an account I own for testing, exemplify what goes in there, and to cause a crash and exemplify the issue page (below). I would remove that before merging, if you decide to merge this.

Sentry is FOSS which means people hosting BaGet can also host Sentry for free and simply add their own DSN to `appsettings.json`.

I suggest [getting a sponsored account at sentry.io](https://sentry.io/for/open-source/) (it's what we did for [NuGetTrends](https://github.com/NuGetTrends/nuget-trends) and leaving a DSN in the `appsettings.json` to collect crashes happening in installations of BaGet around. 
IMHO a note on the README.md would be enough, documenting to delete the DSN from `appsettings.json` to opt out. Or defining the environment variable `SENTRY_DSN` to an empty string which does the same.

With the integration with GitHub, Sentry can also open issues here from events getting into Sentry.

I also suggest setting up [release tracking and suspected commits](https://blog.sentry.io/2018/09/06/expanding-the-sentry-ecosystem-with-new-and-improved-integrations#suspect-commits) if you decide to have a hosted version of baget since that'll tell you likely which commit is involved in the event.

<img width="1669" alt="image" src="https://user-images.githubusercontent.com/1633368/67164687-625efd80-f34b-11e9-8736-74aa71071e20.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1633368/67164692-6ab73880-f34b-11e9-9078-3e92b986eb77.png">

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/1633368/67164696-7a368180-f34b-11e9-88d5-f43035b9b154.png">

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/1633368/67164701-87ec0700-f34b-11e9-85af-a6f75d955a79.png">

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/1633368/67164703-8f131500-f34b-11e9-9662-7e3e0ec30f80.png">
