### PR TITLE
Update to ASP.NET Core 3.0

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -39,10 +39,10 @@ jobs:
   pool:
     vmImage: vs2017-win2016
   steps:
-    - task: DotNetCoreInstaller@0
-      displayName: 'Use .NET Core SDK 3.0.102'
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core SDK 3.0.X'
       inputs:
-        version: 3.0.102
+        version: 3.0.x
 
     - task: Npm@1
       displayName: Install frontend dependencies

--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -40,9 +40,9 @@ jobs:
     vmImage: vs2017-win2016
   steps:
     - task: DotNetCoreInstaller@0
-      displayName: 'Use .NET Core SDK 2.2.100'
+      displayName: 'Use .NET Core SDK 3.0.X'
       inputs:
-        version: 2.2.100
+        version: 3.0.x
 
     - task: Npm@1
       displayName: Install frontend dependencies

--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -40,9 +40,9 @@ jobs:
     vmImage: vs2017-win2016
   steps:
     - task: DotNetCoreInstaller@0
-      displayName: 'Use .NET Core SDK 3.0.X'
+      displayName: 'Use .NET Core SDK 3.0.102'
       inputs:
-        version: 3.0.x
+        version: 3.0.102
 
     - task: Npm@1
       displayName: Install frontend dependencies

--- a/BaGet.sln
+++ b/BaGet.sln
@@ -26,6 +26,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B44364D-952B-497A-82E0-C9AAE94E0369}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		src\Directory.Build.props = src\Directory.Build.props
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BaGet.Core.Server", "src\BaGet.Core.Server\BaGet.Core.Server.csproj", "{D68B56AC-98DD-4DA7-B4F8-1243538A8A5C}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/dotnet:3.0-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:3.0-sdk AS build
+FROM microsoft/dotnet:3.1-sdk AS build
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime AS base
+FROM microsoft/dotnet:3.0-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM microsoft/dotnet:3.0-sdk AS build
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 
 FROM microsoft/dotnet:3.0-sdk AS build
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 WORKDIR /src
 COPY /src .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:3.0-aspnetcore-runtime AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:3.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 WORKDIR /src

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/samples/BaGet.Protocol.Samples.Tests.csproj
+++ b/samples/BaGet.Protocol.Samples.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <NoWarn>IDE0007</NoWarn>

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 
     <PackageTags>NuGet;Amazon;Cloud</PackageTags>
     <Description>The libraries to host BaGet on AWS.</Description>

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 
     <PackageTags>NuGet;Azure;Cloud</PackageTags>
     <Description>The libraries to host BaGet on Azure.</Description>

--- a/src/BaGet.Core.Server/BaGet.Core.Server.csproj
+++ b/src/BaGet.Core.Server/BaGet.Core.Server.csproj
@@ -1,14 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 
     <Description>BaGet's NuGet server implementation</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" version="$(MicrosoftAspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" version="$(MicrosoftAspNetCorePackageVersion)" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Core.Server/Extensions/IEndpointRouteBuilderExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IEndpointRouteBuilderExtensions.cs
@@ -4,119 +4,109 @@ using Microsoft.AspNetCore.Routing.Constraints;
 
 namespace BaGet.Extensions
 {
-    public static class IRouteBuilderExtensions
+    public static class IEndpointRouteBuilderExtensions
     {
-        public static IRouteBuilder MapServiceIndexRoutes(this IRouteBuilder routes)
+        public static void MapServiceIndexRoutes(this IEndpointRouteBuilder endpoints)
         {
-            return routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.IndexRouteName,
-                template: "v3/index.json",
+                pattern: "v3/index.json",
                 defaults: new { controller = "ServiceIndex", action = "Get" });
         }
 
-        public static IRouteBuilder MapPackagePublishRoutes(this IRouteBuilder routes)
+        public static void MapPackagePublishRoutes(this IEndpointRouteBuilder endpoints)
         {
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.UploadPackageRouteName,
-                template: "api/v2/package",
+                pattern: "api/v2/package",
                 defaults: new { controller = "PackagePublish", action = "Upload" },
                 constraints: new { httpMethod = new HttpMethodRouteConstraint("PUT") });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.DeleteRouteName,
-                template: "api/v2/package/{id}/{version}",
+                pattern: "api/v2/package/{id}/{version}",
                 defaults: new { controller = "PackagePublish", action = "Delete" },
                 constraints: new { httpMethod = new HttpMethodRouteConstraint("DELETE") });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.RelistRouteName,
-                template: "api/v2/package/{id}/{version}",
+                pattern: "api/v2/package/{id}/{version}",
                 defaults: new { controller = "PackagePublish", action = "Relist" },
                 constraints: new { httpMethod = new HttpMethodRouteConstraint("POST") });
-
-            return routes;
         }
 
-        public static IRouteBuilder MapSymbolRoutes(this IRouteBuilder routes)
+        public static void MapSymbolRoutes(this IEndpointRouteBuilder endpoints)
         {
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.UploadSymbolRouteName,
-                template: "api/v2/symbol",
+                pattern: "api/v2/symbol",
                 defaults: new { controller = "Symbol", action = "Upload" },
                 constraints: new { httpMethod = new HttpMethodRouteConstraint("PUT") });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.SymbolDownloadRouteName,
-                template: "api/download/symbols/{file}/{key}/{file2}",
+                pattern: "api/download/symbols/{file}/{key}/{file2}",
                 defaults: new { controller = "Symbol", action = "Get" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.PrefixedSymbolDownloadRouteName,
-                template: "api/download/symbols/{prefix}/{file}/{key}/{file2}",
+                pattern: "api/download/symbols/{prefix}/{file}/{key}/{file2}",
                 defaults: new { controller = "Symbol", action = "Get" });
-
-            return routes;
         }
 
-        public static IRouteBuilder MapSearchRoutes(this IRouteBuilder routes)
+        public static void MapSearchRoutes(this IEndpointRouteBuilder endpoints)
         {
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.SearchRouteName,
-                template: "v3/search",
+                pattern: "v3/search",
                 defaults: new { controller = "Search", action = "Search" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.AutocompleteRouteName,
-                template: "v3/autocomplete",
+                pattern: "v3/autocomplete",
                 defaults: new { controller = "Search", action = "Autocomplete" });
 
             // This is an unofficial API to find packages that depend on a given package.
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.DependentsRouteName,
-                template: "v3/dependents",
+                pattern: "v3/dependents",
                 defaults: new { controller = "Search", action = "Dependents" });
-
-            return routes;
         }
 
-        public static IRouteBuilder MapPackageMetadataRoutes(this IRouteBuilder routes)
+        public static void MapPackageMetadataRoutes(this IEndpointRouteBuilder endpoints)
         {
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                name: Routes.RegistrationIndexRouteName,
-               template: "v3/registration/{id}/index.json",
+               pattern: "v3/registration/{id}/index.json",
                defaults: new { controller = "PackageMetadata", action = "RegistrationIndex" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.RegistrationLeafRouteName,
-                template: "v3/registration/{id}/{version}.json",
+                pattern: "v3/registration/{id}/{version}.json",
                 defaults: new { controller = "PackageMetadata", action = "RegistrationLeaf" });
-
-            return routes;
         }
 
-        public static IRouteBuilder MapPackageContentRoutes(this IRouteBuilder routes)
+        public static void MapPackageContentRoutes(this IEndpointRouteBuilder endpoints)
         {
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.PackageVersionsRouteName,
-                template: "v3/package/{id}/index.json",
+                pattern: "v3/package/{id}/index.json",
                 defaults: new { controller = "PackageContent", action = "GetPackageVersions" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.PackageDownloadRouteName,
-                template: "v3/package/{id}/{version}/{idVersion}.nupkg",
+                pattern: "v3/package/{id}/{version}/{idVersion}.nupkg",
                 defaults: new { controller = "PackageContent", action = "DownloadPackage" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.PackageDownloadManifestRouteName,
-                template: "v3/package/{id}/{version}/{id2}.nuspec",
+                pattern: "v3/package/{id}/{version}/{id2}.nuspec",
                 defaults: new { controller = "PackageContent", action = "DownloadNuspec" });
 
-            routes.MapRoute(
+            endpoints.MapControllerRoute(
                 name: Routes.PackageDownloadReadmeRouteName,
-                template: "v3/package/{id}/{version}/readme",
+                pattern: "v3/package/{id}/{version}/readme",
                 defaults: new { controller = "PackageContent", action = "DownloadReadme" });
-
-            return routes;
         }
     }
 }

--- a/src/BaGet.Core.Server/Extensions/IHostExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IHostExtensions.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BaGet.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace BaGet.Extensions
+{
+    public static class IHostExtensions
+    {
+        public static async Task RunMigrationsAsync(this IHost host, CancellationToken cancellationToken)
+        {
+            // Run migrations if necessary.
+            var options = host.Services.GetRequiredService<IOptions<BaGetOptions>>();
+
+            if (options.Value.RunMigrationsAtStartup && options.Value.Database.Type != DatabaseType.AzureTable)
+            {
+                using (var scope = host.Services.CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<IContext>();
+
+                    // TODO: An "InvalidOperationException" is thrown and caught due to a bug
+                    // in EF Core 3.0. This is fixed in 3.1.
+                    // See: https://github.com/dotnet/efcore/issues/18307
+                    await ctx.Database.MigrateAsync(cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/src/BaGet.Core.Server/Extensions/IRouteBuilderExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IRouteBuilderExtensions.cs
@@ -49,9 +49,9 @@ namespace BaGet.Extensions
                 name: Routes.SymbolDownloadRouteName,
                 template: "api/download/symbols/{file}/{key}/{file2}",
                 defaults: new { controller = "Symbol", action = "Get" });
-            
+
             routes.MapRoute(
-                name: Routes.SymbolDownloadRouteName,
+                name: Routes.PrefixedSymbolDownloadRouteName,
                 template: "api/download/symbols/{prefix}/{file}/{key}/{file2}",
                 defaults: new { controller = "Symbol", action = "Get" });
 

--- a/src/BaGet.Core.Server/Extensions/IRouteBuilderExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IRouteBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace BaGet.Extensions
             return routes.MapRoute(
                 name: Routes.IndexRouteName,
                 template: "v3/index.json",
-                defaults: new { controller = "ServiceIndex", action = "GetAsync" });
+                defaults: new { controller = "ServiceIndex", action = "Get" });
         }
 
         public static IRouteBuilder MapPackagePublishRoutes(this IRouteBuilder routes)
@@ -63,18 +63,18 @@ namespace BaGet.Extensions
             routes.MapRoute(
                 name: Routes.SearchRouteName,
                 template: "v3/search",
-                defaults: new { controller = "Search", action = "SearchAsync" });
+                defaults: new { controller = "Search", action = "Search" });
 
             routes.MapRoute(
                 name: Routes.AutocompleteRouteName,
                 template: "v3/autocomplete",
-                defaults: new { controller = "Search", action = "AutocompleteAsync" });
+                defaults: new { controller = "Search", action = "Autocomplete" });
 
             // This is an unofficial API to find packages that depend on a given package.
             routes.MapRoute(
                 name: Routes.DependentsRouteName,
                 template: "v3/dependents",
-                defaults: new { controller = "Search", action = "DependentsAsync" });
+                defaults: new { controller = "Search", action = "Dependents" });
 
             return routes;
         }
@@ -84,12 +84,12 @@ namespace BaGet.Extensions
             routes.MapRoute(
                name: Routes.RegistrationIndexRouteName,
                template: "v3/registration/{id}/index.json",
-               defaults: new { controller = "PackageMetadata", action = "RegistrationIndexAsync" });
+               defaults: new { controller = "PackageMetadata", action = "RegistrationIndex" });
 
             routes.MapRoute(
                 name: Routes.RegistrationLeafRouteName,
                 template: "v3/registration/{id}/{version}.json",
-                defaults: new { controller = "PackageMetadata", action = "RegistrationLeafAsync" });
+                defaults: new { controller = "PackageMetadata", action = "RegistrationLeaf" });
 
             return routes;
         }
@@ -99,22 +99,22 @@ namespace BaGet.Extensions
             routes.MapRoute(
                 name: Routes.PackageVersionsRouteName,
                 template: "v3/package/{id}/index.json",
-                defaults: new { controller = "PackageContent", action = "GetPackageVersionsAsync" });
+                defaults: new { controller = "PackageContent", action = "GetPackageVersions" });
 
             routes.MapRoute(
                 name: Routes.PackageDownloadRouteName,
                 template: "v3/package/{id}/{version}/{idVersion}.nupkg",
-                defaults: new { controller = "PackageContent", action = "DownloadPackageAsync" });
+                defaults: new { controller = "PackageContent", action = "DownloadPackage" });
 
             routes.MapRoute(
                 name: Routes.PackageDownloadManifestRouteName,
                 template: "v3/package/{id}/{version}/{id2}.nuspec",
-                defaults: new { controller = "PackageContent", action = "DownloadNuspecAsync" });
+                defaults: new { controller = "PackageContent", action = "DownloadNuspec" });
 
             routes.MapRoute(
                 name: Routes.PackageDownloadReadmeRouteName,
                 template: "v3/package/{id}/{version}/readme",
-                defaults: new { controller = "PackageContent", action = "DownloadReadmeAsync" });
+                defaults: new { controller = "PackageContent", action = "DownloadReadme" });
 
             return routes;
         }

--- a/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
@@ -14,10 +14,6 @@ namespace BaGet.Core.Server.Extensions
     {
         public static IServiceCollection ConfigureHttpServices(this IServiceCollection services)
         {
-            // TODO: Consider replacing "AddMvc" with "AddControllers".
-            // See: https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio#mvc-service-registration
-            // TODO: Consider replacing "AddMvc" with Endpoint Routing
-            // See: options => options.EnableEndpointRouting = false
             services
                 .AddControllers()
                 .AddApplicationPart(typeof(PackageContentController).Assembly)

--- a/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace BaGet.Core.Server.Extensions
             // TODO: Consider replacing "AddMvc" with Endpoint Routing
             // See: options => options.EnableEndpointRouting = false
             services
-                .AddControllers(options => options.EnableEndpointRouting = false)
+                .AddControllers()
                 .AddApplicationPart(typeof(PackageContentController).Assembly)
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>

--- a/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using BaGet.Configuration;
+using BaGet.Controllers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http.Features;
@@ -19,7 +20,7 @@ namespace BaGet.Core.Server.Extensions
             // See: options => options.EnableEndpointRouting = false
             services
                 .AddControllers(options => options.EnableEndpointRouting = false)
-                .AddApplicationPart(typeof(BaGet.Controllers.PackageContentController).Assembly)
+                .AddApplicationPart(typeof(PackageContentController).Assembly)
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>
                 {

--- a/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IServiceCollectionExtensions.cs
@@ -13,15 +13,18 @@ namespace BaGet.Core.Server.Extensions
     {
         public static IServiceCollection ConfigureHttpServices(this IServiceCollection services)
         {
+            // TODO: Consider replacing "AddMvc" with "AddControllers".
+            // See: https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio#mvc-service-registration
+            // TODO: Consider replacing "AddMvc" with Endpoint Routing
+            // See: options => options.EnableEndpointRouting = false
             services
-                .AddMvc()
+                .AddControllers(options => options.EnableEndpointRouting = false)
                 .AddApplicationPart(typeof(BaGet.Controllers.PackageContentController).Assembly)
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
-                .AddJsonOptions(options =>
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+                .AddNewtonsoftJson(options =>
                 {
                     options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
                 });
-
 
             services.AddCors();
             services.AddHttpContextAccessor();

--- a/src/BaGet.Core.Server/Routes.cs
+++ b/src/BaGet.Core.Server/Routes.cs
@@ -17,5 +17,6 @@ namespace BaGet
         public const string PackageDownloadManifestRouteName = "package-download-manifest";
         public const string PackageDownloadReadmeRouteName = "package-download-readme";
         public const string SymbolDownloadRouteName = "symbol-download";
+        public const string PrefixedSymbolDownloadRouteName = "prefixed-symbol-download";
     }
 }

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 
     <Description>The core libraries that power BaGet.</Description>
   </PropertyGroup>

--- a/src/BaGet.Core/Search/DatabaseSearchService.cs
+++ b/src/BaGet.Core/Search/DatabaseSearchService.cs
@@ -214,8 +214,8 @@ namespace BaGet.Core
             }
 
             var packageIds = search.Select(p => p.Id)
-                .OrderBy(id => id)
                 .Distinct()
+                .OrderBy(id => id)
                 .Skip(skip)
                 .Take(take);
 

--- a/src/BaGet.Core/Storage/PackageStorageService.cs
+++ b/src/BaGet.Core/Storage/PackageStorageService.cs
@@ -62,7 +62,7 @@ namespace BaGet.Core
                     lowercasedNormalizedVersion,
                     packagePath);
 
-                throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion}");
+                throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion} due to conflict");
             }
 
             // Store the package's nuspec.
@@ -82,7 +82,7 @@ namespace BaGet.Core
                     lowercasedNormalizedVersion,
                     nuspecPath);
 
-                throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion} nuspec");
+                throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion} nuspec due to conflict");
             }
 
             // Store the package's readme, if one exists.
@@ -104,7 +104,7 @@ namespace BaGet.Core
                         lowercasedNormalizedVersion,
                         readmePath);
 
-                    throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion} readme");
+                    throw new InvalidOperationException($"Failed to store package {lowercasedId} {lowercasedNormalizedVersion} readme due to conflict");
                 }
             }
 

--- a/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
+++ b/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
+++ b/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
+++ b/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.SqlServer/SqlServerContext.cs
+++ b/src/BaGet.Database.SqlServer/SqlServerContext.cs
@@ -1,6 +1,6 @@
-using System.Data.SqlClient;
 using System.Linq;
 using BaGet.Core;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 namespace BaGet.Database.SqlServer

--- a/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
+++ b/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Gcp/BaGet.Gcp.csproj
+++ b/src/BaGet.Gcp/BaGet.Gcp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 
     <PackageTags>NuGet;Google;Cloud</PackageTags>
     <Description>The libraries to host BaGet on the Google Cloud Platform.</Description>

--- a/src/BaGet.UI/src/DisplayPackage/DisplayPackage.tsx
+++ b/src/BaGet.UI/src/DisplayPackage/DisplayPackage.tsx
@@ -2,7 +2,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import timeago from 'timeago.js';
-import { coerce, gt, SemVer } from 'semver';
+import { coerce, eq, gt, SemVer } from 'semver';
 
 import { config } from '../config';
 import Dependencies from './Dependencies';
@@ -27,7 +27,6 @@ interface IDisplayPackageProps {
 
 interface IPackage {
   id: string;
-  latestVersion: string;
   hasReadme: boolean;
   description: string;
   readme: string;
@@ -62,7 +61,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
   };
 
   private id: string;
-  private version?: string;
+  private version: SemVer | null;
 
   private registrationController: AbortController;
   private readmeController: AbortController;
@@ -74,7 +73,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
     this.readmeController = new AbortController();
 
     this.id = props.match.params.id.toLowerCase();
-    this.version = props.match.params.version;
+    this.version = coerce(props.match.params.version);
     this.state = DisplayPackage.initialState;
   }
 
@@ -94,7 +93,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       this.readmeController = new AbortController();
 
       this.id = this.props.match.params.id.toLowerCase();
-      this.version = this.props.match.params.version;
+      this.version = coerce(this.props.match.params.version);
       this.setState(DisplayPackage.initialState);
       this.componentDidMount();
     }
@@ -126,9 +125,13 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
         if (!entry.catalogEntry.listed) continue;
 
         const normalizedVersion = this.normalizeVersion(entry.catalogEntry.version);
-        const isCurrent = !!this.version
-          ? normalizedVersion === this.version
-          : normalizedVersion === latestVersion;
+        const coercedVersion = coerce(entry.catalogEntry.version);
+
+        if (coercedVersion === null) continue;
+
+        const isCurrent = latestVersion !== null && coercedVersion !== null
+          ? eq(coercedVersion, !!this.version ? this.version : latestVersion)
+          : false;
 
         versions.push({
           date: new Date(entry.catalogEntry.published),
@@ -167,7 +170,6 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
             downloadUrl: currentItem.packageContent,
             packageType,
             lastUpdate,
-            latestVersion,
             normalizedVersion: this.normalizeVersion(currentItem.catalogEntry.version),
             readme,
             totalDownloads: results.totalDownloads,
@@ -316,8 +318,7 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       : version.substring(0, buildMetadataStart);
   }
 
-  private latestVersion(index: Registration.IRegistrationIndex): string | null {
-    let latestVersionString: string | null = null;
+  private latestVersion(index: Registration.IRegistrationIndex): SemVer | null {
     let latestVersion: SemVer | null = null;
     for (const entry of index.items[0].items) {
       if (!entry.catalogEntry.listed) continue;
@@ -325,13 +326,12 @@ class DisplayPackage extends React.Component<IDisplayPackageProps, IDisplayPacka
       let entryVersion = coerce(entry.catalogEntry.version);
       if (!!entryVersion) {
         if (latestVersion === null || gt(entryVersion, latestVersion)) {
-          latestVersionString = entry.catalogEntry.version;
           latestVersion = entryVersion;
         }
       }
     }
 
-    return latestVersionString;
+    return latestVersion;
   }
 }
 

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
-    <!-- TODO: Remove once replaced MVC with Endpoint Routing -->
-    <NoWarn>$(NoWarn);MVC1005</NoWarn>
-
     <SpaRoot>..\BaGet.UI\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
   </PropertyGroup>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -1,25 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <!-- TODO: Remove once replaced MVC with Endpoint Routing -->
+    <NoWarn>$(NoWarn);MVC1005</NoWarn>
 
     <SpaRoot>..\BaGet.UI\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Entities\**" />
-    <Content Remove="Entities\**" />
-    <EmbeddedResource Remove="Entities\**" />
-    <None Remove="Entities\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,9 +21,9 @@
     <ProjectReference Include="..\BaGet.Core\BaGet.Core.csproj" />
     <ProjectReference Include="..\BaGet.Core.Server\BaGet.Core.Server.csproj" />
     <ProjectReference Include="..\BaGet.Database.MySql\BaGet.Database.MySql.csproj" />
+    <ProjectReference Include="..\BaGet.Database.PostgreSql\BaGet.Database.PostgreSql.csproj" />
     <ProjectReference Include="..\BaGet.Database.Sqlite\BaGet.Database.Sqlite.csproj" />
     <ProjectReference Include="..\BaGet.Database.SqlServer\BaGet.Database.SqlServer.csproj" />
-    <ProjectReference Include="..\BaGet.Database.PostgreSql\BaGet.Database.PostgreSql.csproj" />
     <ProjectReference Include="..\BaGet.Gcp\BaGet.Gcp.csproj" />
     <ProjectReference Include="..\BaGet.Protocol\BaGet.Protocol.csproj" />
   </ItemGroup>

--- a/src/BaGet/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet/Extensions/IServiceCollectionExtensions.cs
@@ -342,8 +342,8 @@ namespace BaGet.Extensions
                 return client;
             });
 
-            services.AddSingleton<DownloadsImporter>();
-            services.AddSingleton<IPackageDownloadsSource, PackageDownloadsJsonSource>();
+            services.AddScoped<DownloadsImporter>();
+            services.AddScoped<IPackageDownloadsSource, PackageDownloadsJsonSource>();
 
             return services;
         }

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -44,7 +44,7 @@ namespace BaGet
             {
                 var host = CreateWebHostBuilder(args).Build();
 
-                await RunMigrationsAsync(host, cancellationToken);
+                await host.RunMigrationsAsync(cancellationToken);
                 await host.RunAsync(cancellationToken);
             });
 
@@ -81,25 +81,6 @@ namespace BaGet
                 .ConfigureBaGetConfiguration(args)
                 .ConfigureBaGetServices()
                 .ConfigureBaGetLogging();
-        }
-
-        private static async Task RunMigrationsAsync(IHost host, CancellationToken cancellationToken)
-        {
-            // Run migrations if necessary.
-            var options = host.Services.GetRequiredService<IOptions<BaGetOptions>>();
-
-            if (options.Value.RunMigrationsAtStartup && options.Value.Database.Type != DatabaseType.AzureTable)
-            {
-                using (var scope = host.Services.CreateScope())
-                {
-                    var ctx = scope.ServiceProvider.GetRequiredService<IContext>();
-
-                    // TODO: An "InvalidOperationException" is thrown and caught due to a bug
-                    // in EF Core 3.0. This is fixed in 3.1.
-                    // See: https://github.com/dotnet/efcore/issues/18307
-                    await ctx.Database.MigrateAsync(cancellationToken);
-                }
-            }
         }
     }
 }

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using BaGet.Core;
 using BaGet.Extensions;
 using McMaster.Extensions.CommandLineUtils;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace BaGet
 {
@@ -40,34 +42,61 @@ namespace BaGet
 
             app.OnExecute(() =>
             {
-                CreateWebHostBuilder(args).Build().Run();
+                var host = CreateWebHostBuilder(args).Build();
+
+                RunMigrationsAsync(host).GetAwaiter().GetResult();
+                host.Run();
             });
 
             app.Execute(args);
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .UseKestrel(options =>
+        public static IHostBuilder CreateWebHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    // Remove the upload limit from Kestrel. If needed, an upload limit can
-                    // be enforced by a reverse proxy server, like IIS.
-                    options.Limits.MaxRequestBodySize = null;
+                    webBuilder
+                        .ConfigureKestrel(options =>
+                        {
+                            // Remove the upload limit from Kestrel. If needed, an upload limit can
+                            // be enforced by a reverse proxy server, like IIS.
+                            options.Limits.MaxRequestBodySize = null;
+                        })
+                        .UseStartup<Startup>();
                 })
                 .ConfigureAppConfiguration((builderContext, config) =>
                 {
                     var root = Environment.GetEnvironmentVariable("BAGET_CONFIG_ROOT");
                     if (!string.IsNullOrEmpty(root))
+                    {
                         config.SetBasePath(root);
+                    }
                 });
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
+            // TODO: Merge 'CreateWebHostBuilder' and 'CreateHostBuilder'
+            // See: https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio#configuration
             return new HostBuilder()
                 .ConfigureBaGetConfiguration(args)
                 .ConfigureBaGetServices()
                 .ConfigureBaGetLogging();
+        }
+
+        private static async Task RunMigrationsAsync(IHost host)
+        {
+            // Run migrations if necessary.
+            var options = host.Services.GetRequiredService<IOptions<BaGetOptions>>();
+
+            if (options.Value.RunMigrationsAtStartup && options.Value.Database.Type != DatabaseType.AzureTable)
+            {
+                using (var scope = host.Services.CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<IContext>();
+
+                    await ctx.Database.MigrateAsync();
+                }
+            }
         }
     }
 }

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -43,24 +43,23 @@ namespace BaGet
                 app.UseStatusCodePages();
             }
 
-            app.UseRouting();
-
-            app.UsePathBase(options.PathBase);
-            app.UseForwardedHeaders();
             app.UseSpaStaticFiles();
 
+            app.UseRouting();
+
+            app.UseForwardedHeaders();
+            app.UsePathBase(options.PathBase);
             app.UseCors(ConfigureCorsOptions.CorsPolicy);
             app.UseOperationCancelledMiddleware();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes
-                    .MapServiceIndexRoutes()
-                    .MapPackagePublishRoutes()
-                    .MapSymbolRoutes()
-                    .MapSearchRoutes()
-                    .MapPackageMetadataRoutes()
-                    .MapPackageContentRoutes();
+                endpoints.MapServiceIndexRoutes();
+                endpoints.MapPackagePublishRoutes();
+                endpoints.MapSymbolRoutes();
+                endpoints.MapSearchRoutes();
+                endpoints.MapPackageMetadataRoutes();
+                endpoints.MapPackageContentRoutes();
             });
 
             app.UseSpa(spa =>

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -6,9 +6,9 @@ using BaGet.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace BaGet
 {
@@ -33,26 +33,17 @@ namespace BaGet
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            var options = Configuration.Get<BaGetOptions>();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
                 app.UseStatusCodePages();
             }
 
-            // Run migrations if necessary.
-            var options = Configuration.Get<BaGetOptions>();
-            if (options.RunMigrationsAtStartup && options.Database.Type != DatabaseType.AzureTable)
-            {
-                using (var scope = app.ApplicationServices.CreateScope())
-                {
-                    scope.ServiceProvider
-                        .GetRequiredService<IContext>()
-                        .Database
-                        .Migrate();
-                }
-            }
+            app.UseRouting();
 
             app.UsePathBase(options.PathBase);
             app.UseForwardedHeaders();

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -31,6 +31,7 @@
     },
     "Console": {
       "LogLevel": {
+        "Microsoft.Hosting.Lifetime": "Information",
         "Default": "Warning"
       }
     }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Product>BaGet</Product>
 
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0-prerelease</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.3.0-prerelease</PackageVersion>
     <PackageProjectUrl>https://loic-sharma.github.io/BaGet/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,9 +27,9 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <MicrosoftAspNetCorePackageVersion>2.2.0</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftEntityFrameworkCorePackageVersion>2.2.2</MicrosoftEntityFrameworkCorePackageVersion>
-    <MicrosoftExtensionsPackageVersion>2.2.0</MicrosoftExtensionsPackageVersion>
+    <MicrosoftAspNetCorePackageVersion>3.0.2</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>3.0.2</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftExtensionsPackageVersion>3.0.2</MicrosoftExtensionsPackageVersion>
     <NuGetPackageVersion>5.0.0-rtm.5856</NuGetPackageVersion>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Product>BaGet</Product>
 
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.3.0-prerelease</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0-prerelease</PackageVersion>
     <PackageProjectUrl>https://loic-sharma.github.io/BaGet/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -1,21 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.1</LangVersion>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -1,21 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.1</LangVersion>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -1,27 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.1</LangVersion>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NuGet.Protocol" Version="5.0.0-rtm.5856" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DebugType>portable</DebugType>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <!-- NuGet dependencies shared across projects -->
+  <PropertyGroup>
+    <MicrosoftAspNetCorePackageVersion>3.0.2</MicrosoftAspNetCorePackageVersion>
+    <MoqPackageVersion>4.10.0</MoqPackageVersion>
+    <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
+    <NuGetPackageVersion>5.0.0-rtm.5856</NuGetPackageVersion>
+    <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Updates BaGet to ASP.NET Core 3.0. This is based off @MarkZither's work (see https://github.com/loic-sharma/BaGet/pull/443). Thank you for all the help @MarkZither!

⚠️ Many of BaGet's projects will **temporarily** require .NET Core 3 because EF Core 3.0 requires .NET Standard 2.1. EF Core 3.1 reintroduced .NET Standard 2.0 support. I will re-add .NET Framework and .NET Standard 2.0 support once I've migrated BaGet to ASP.NET Core 3.1.

<details>
<summary>Test plan</summary>

Build: https://dev.azure.com/sharml/BaGet/_build/results?buildId=1119

* [ ] Databases
    * [x] SQLite
    * [ ] MySQL
    * [ ] PostgreSQL
    * [x] SQL Server
* [ ] Storage
    * [ ] Azure
    * [x] Filesystem
    * [ ] GCP
    * [ ] AWS
* [x] Docker
* [x] GitHub release
* [x] Clients
    * [x] nuget.exe
    * [x] dotnet CLI
    * [x] Visual Studio
</details>

Part of https://github.com/loic-sharma/BaGet/issues/439
