### PR TITLE
Update to ASP.NET Core 3.1

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -40,9 +40,9 @@ jobs:
     vmImage: vs2017-win2016
   steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 3.0.X'
+      displayName: 'Use .NET Core SDK 3.1.X'
       inputs:
-        version: 3.0.x
+        version: 3.1.x
 
     - task: Npm@1
       displayName: Install frontend dependencies

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <PackageTags>NuGet;Amazon;Cloud</PackageTags>
     <Description>The libraries to host BaGet on AWS.</Description>

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <PackageTags>NuGet;Azure;Cloud</PackageTags>
     <Description>The libraries to host BaGet on Azure.</Description>

--- a/src/BaGet.Core.Server/BaGet.Core.Server.csproj
+++ b/src/BaGet.Core.Server/BaGet.Core.Server.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
+    <PackageTags>NuGet</PackageTags>
     <Description>BaGet's NuGet server implementation</Description>
   </PropertyGroup>
 

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
+    <PackageTags>NuGet</PackageTags>
     <Description>The core libraries that power BaGet.</Description>
   </PropertyGroup>
 

--- a/src/BaGet.Core/Entities/AbstractContext.cs
+++ b/src/BaGet.Core/Entities/AbstractContext.cs
@@ -64,8 +64,9 @@ namespace BaGet.Core
                 .HasMaxLength(MaxPackageVersionLength);
 
             package.Property(p => p.Authors)
+                .HasMaxLength(DefaultMaxStringLength)
                 .HasConversion(StringArrayToJsonConverter.Instance)
-                .HasMaxLength(DefaultMaxStringLength);
+                .Metadata.SetValueComparer(StringArrayComparer.Instance);
 
             package.Property(p => p.IconUrl)
                 .HasConversion(UriToStringConverter.Instance)
@@ -84,8 +85,9 @@ namespace BaGet.Core
                 .HasMaxLength(DefaultMaxStringLength);
 
             package.Property(p => p.Tags)
+                .HasMaxLength(DefaultMaxStringLength)
                 .HasConversion(StringArrayToJsonConverter.Instance)
-                .HasMaxLength(DefaultMaxStringLength);
+                .Metadata.SetValueComparer(StringArrayComparer.Instance);
 
             package.Property(p => p.Description).HasMaxLength(DefaultMaxStringLength);
             package.Property(p => p.Language).HasMaxLength(MaxPackageLanguageLength);

--- a/src/BaGet.Core/Entities/Converters/StringArrayComparer.cs
+++ b/src/BaGet.Core/Entities/Converters/StringArrayComparer.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace BaGet.Core
+{
+    public class StringArrayComparer : ValueComparer<string[]>
+    {
+        public static readonly StringArrayComparer Instance = new StringArrayComparer();
+
+        public StringArrayComparer()
+            : base(
+                (c1, c2) => c1.SequenceEqual(c2),
+                c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                c => c.ToArray())
+        {
+        }
+    }
+}

--- a/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
+++ b/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+
+    <PackageTags>NuGet</PackageTags>
+    <Description>The libraries to host BaGet on MySQL.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
+++ b/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
@@ -1,11 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+
+    <PackageTags>NuGet</PackageTags>
+    <Description>The libraries to host BaGet on PostgreSQL.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
+++ b/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+
+    <PackageTags>NuGet</PackageTags>
+    <Description>The libraries to host BaGet on SQL Server.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
+++ b/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+
+    <PackageTags>NuGet</PackageTags>
+    <Description>The libraries to host BaGet on SQLite.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Gcp/BaGet.Gcp.csproj
+++ b/src/BaGet.Gcp/BaGet.Gcp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <PackageTags>NuGet;Google;Cloud</PackageTags>
     <Description>The libraries to host BaGet on the Google Cloud Platform.</Description>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
   </ItemGroup>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <SpaRoot>..\BaGet.UI\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,9 +27,9 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <MicrosoftAspNetCorePackageVersion>3.0.2</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftEntityFrameworkCorePackageVersion>3.0.2</MicrosoftEntityFrameworkCorePackageVersion>
-    <MicrosoftExtensionsPackageVersion>3.0.2</MicrosoftExtensionsPackageVersion>
+    <MicrosoftAspNetCorePackageVersion>3.1.1</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>3.1.1</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftExtensionsPackageVersion>3.1.1</MicrosoftExtensionsPackageVersion>
     <NuGetPackageVersion>5.0.0-rtm.5856</NuGetPackageVersion>
   </PropertyGroup>
 

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
⚠️ This is still a work in progress!

Updates BaGet to ASP.NET Core 3.1. This is based off @MarkZither's work (see https://github.com/loic-sharma/BaGet/pull/443). Thank you for all the help @MarkZither!

TODO:
* [x] Fix `The property ... on entity type ... is a collection or enumeration type with a value converter but with no value comparer.` warnings. See https://github.com/dotnet/efcore/issues/17471#issuecomment-526330450
* [ ] ⚠️ SPA proxy to React development server throws exceptions incessantly. See https://github.com/dotnet/aspnetcore/issues/18470

<details>
<summary>Test plan</summary>

* [x] Databases
    * [x] SQLite
    * [x] MySQL
    * [x] PostgreSQL
    * [X] SQL Server
* [ ] Storage
    * [ ] Azure
    * [x] Filesystem
    * [ ] GCP
    * [ ] AWS
* [x] Docker
* [x] GitHub release
* [x] Clients
    * [X] nuget.exe
    * [X] dotnet CLI
    * [x] Visual Studio
</details>

Part of https://github.com/loic-sharma/BaGet/issues/439