### PR TITLE
Refactor download tracking

### DIFF
--- a/src/BaGet.Core/Content/DefaultPackageContentService.cs
+++ b/src/BaGet.Core/Content/DefaultPackageContentService.cs
@@ -66,11 +66,13 @@ namespace BaGet.Core.Content
             // Allow read-through caching if it is configured.
             await _mirror.MirrorAsync(id, version, cancellationToken);
 
-            if (!await _packages.AddDownloadAsync(id, version, cancellationToken))
+            var package = await _packages.FindOrNullAsync(id, version, includeUnlisted: true, cancellationToken);
+            if (package == null)
             {
                 return null;
             }
 
+            await _packages.AddDownloadAsync(package, cancellationToken);
             return await _storage.GetPackageStreamAsync(id, version, cancellationToken);
         }
 

--- a/src/BaGet.Core/Entities/AbstractContext.cs
+++ b/src/BaGet.Core/Entities/AbstractContext.cs
@@ -29,8 +29,6 @@ namespace BaGet.Core
         public DbSet<PackageType> PackageTypes { get; set; }
         public DbSet<TargetFramework> TargetFrameworks { get; set; }
 
-        public Task<int> SaveChangesAsync() => SaveChangesAsync(default);
-
         public abstract bool IsUniqueConstraintViolationException(DbUpdateException exception);
 
         public virtual bool SupportsLimitInSubqueries => true;

--- a/src/BaGet.Core/IPackageService.cs
+++ b/src/BaGet.Core/IPackageService.cs
@@ -80,11 +80,9 @@ namespace BaGet.Core
         /// <summary>
         /// Increment a package's download count.
         /// </summary>
-        /// <param name="id">The id of the package to update.</param>
-        /// <param name="version">The id of the package to update.</param>
+        /// <param name="package">The package to update.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
-        /// <returns>False if the package does not exist.</returns>
-        Task<bool> AddDownloadAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
+        Task AddDownloadAsync(Package package, CancellationToken cancellationToken);
 
         /// <summary>
         /// Completely remove the package from the database.

--- a/src/BaGet.Core/PackageService.cs
+++ b/src/BaGet.Core/PackageService.cs
@@ -97,9 +97,10 @@ namespace BaGet.Core
             return TryUpdatePackageAsync(id, version, p => p.Listed = true, cancellationToken);
         }
 
-        public Task<bool> AddDownloadAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+        public async Task AddDownloadAsync(Package package, CancellationToken cancellationToken)
         {
-            return TryUpdatePackageAsync(id, version, p => p.Downloads += 1, cancellationToken);
+            package.Downloads += 1;
+            await _context.SaveChangesAsync(cancellationToken);
         }
 
         public async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)


### PR DESCRIPTION
Previously the `IPackageService.AddDownloadAsync` returned `false` if the package does not exist, which was used to determine whether we should 404 the package download request. This coupling of "does the package exist" with "track the download" isn't necessary and makes it harder to add buffering to download tracking.