### PR TITLE
Documentation typos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ caching to:
 1. Speed up your builds if restores from [nuget.org](https://nuget.org) are slow
 1. Enable package restores in offline scenarios
 
-The following `Mirror` settings configures BaGet to index packages from [nuget.org](https://nuget.org):
+The following `Mirror` setting configures BaGet to index packages from [nuget.org](https://nuget.org):
 
 ```json
 {
@@ -66,7 +66,7 @@ downloaded if you know the package's id and version. You can override this behav
 
 ## Enable Package Overwrites
 
-Normally, BaGet will reject a package upload if the id and version is already taken. You can configure BaGet
+Normally, BaGet will reject a package upload if the id and version are already taken. You can configure BaGet
 to overwrite the already existing package by setting `AllowPackageOverwrites`:
 
 ```json

--- a/docs/quickstart/gcp.md
+++ b/docs/quickstart/gcp.md
@@ -6,7 +6,7 @@
 We're open source and accept contributions!
 [Fork us on GitHub](https://github.com/loic-sharma/BaGet).
 
-Before you begin, you should decide [which AppEngine region](https://cloud.google.com/appengine/docs/locations)
+Before you begin, you should decide which [AppEngine region](https://cloud.google.com/appengine/docs/locations)
 you will use. For best performance, Cloud Storage and Cloud SQL should be located
 in the same region as your AppEngine deployment.
 


### PR DESCRIPTION
Fix some typos:

`The following Mirror **setting** configures BaGet`
`BaGet will reject a package upload if the id and version **are** already taken`
in https://loic-sharma.github.io/BaGet/configuration/#enable-read-through-caching 

Remove `which `from hyperlink in `which App Engine region`
in https://loic-sharma.github.io/BaGet/quickstart/gcp/

Addresses #255