### PR TITLE
[PostgreSQL] No longer require restart after creating the database

### DIFF
--- a/src/BaGet.Core.Server/Extensions/IHostExtensions.cs
+++ b/src/BaGet.Core.Server/Extensions/IHostExtensions.cs
@@ -21,10 +21,7 @@ namespace BaGet.Extensions
                 {
                     var ctx = scope.ServiceProvider.GetRequiredService<IContext>();
 
-                    // TODO: An "InvalidOperationException" is thrown and caught due to a bug
-                    // in EF Core 3.0. This is fixed in 3.1.
-                    // See: https://github.com/dotnet/efcore/issues/18307
-                    await ctx.Database.MigrateAsync(cancellationToken);
+                    await ctx.RunMigrationsAsync(cancellationToken);
                 }
             }
         }

--- a/src/BaGet.Core/Entities/AbstractContext.cs
+++ b/src/BaGet.Core/Entities/AbstractContext.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -30,6 +31,9 @@ namespace BaGet.Core
         public DbSet<TargetFramework> TargetFrameworks { get; set; }
 
         public Task<int> SaveChangesAsync() => SaveChangesAsync(default);
+
+        public virtual async Task RunMigrationsAsync(CancellationToken cancellationToken)
+            => await Database.MigrateAsync(cancellationToken);
 
         public abstract bool IsUniqueConstraintViolationException(DbUpdateException exception);
 

--- a/src/BaGet.Core/Entities/IContext.cs
+++ b/src/BaGet.Core/Entities/IContext.cs
@@ -24,5 +24,13 @@ namespace BaGet.Core
         bool SupportsLimitInSubqueries { get; }
 
         Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Applies any pending migrations for the context to the database.
+        /// Creates the database if it does not already exist.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the task.</param>
+        /// <returns>A task that completes once migrations are applied.</returns>
+        Task RunMigrationsAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Npgsql, the PostgreSQL driver, caches the database's type information on the initial connection. This causes issues when BaGet creates the database as it adds the citext extension to support case insensitive columns. BaGet will now forcefully reload the database's types after migrations are run.

See: https://github.com/loic-sharma/BaGet/issues/442
See: https://github.com/npgsql/efcore.pg/issues/170#issuecomment-303417225