### PR TITLE
Allow maximum published package size to be configured when using IIS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,10 +130,10 @@ There are two settings related to the database configuration:
 - **Type**: The database engine to use, this should be one of the strings from the above list such as `PostgreSql` or `Sqlite`.
 - **ConnectionString**: The connection string for your database engine.
 
-## Maximum Published Package Size in IIS
+## IIS Server Options
 
-When BaGet is running behind an IIS proxy, the maximum size of a published package is 30MB by default, if not specified (https://github.com/aspnet/Announcements/issues/267).
-This can be modified in BaGet configuration and has an initial setting of 250MB. 
+IIS Server options can be configured under the `IISServerOptions` key. The available options are detailed at [docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.iisserveroptions)
+Note: If not specified, the MaxRequestBodySize in BaGet defaults to 250MB (262144000 bytes), rather than the ASP.NET Core default of 30MB
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,3 +129,20 @@ There are two settings related to the database configuration:
 
 - **Type**: The database engine to use, this should be one of the strings from the above list such as `PostgreSql` or `Sqlite`.
 - **ConnectionString**: The connection string for your database engine.
+
+## Maximum Published Package Size in IIS
+
+When BaGet is running behind an IIS proxy, the maximum size of a published package is 30MB by default, if not specified (https://github.com/aspnet/Announcements/issues/267).
+This can be modified in BaGet configuration and has an initial setting of 250MB. 
+
+```json
+{
+    ...
+
+    "IISServerOptions": {
+        "MaxRequestBodySize": 262144000
+    },
+
+    ...
+}
+```

--- a/docs/quickstart/iis-proxy.md
+++ b/docs/quickstart/iis-proxy.md
@@ -44,6 +44,6 @@ Ensure that the configuration's storage `Path` has the appropriate forward slash
 Note that you will need to adjust folder permissions if the `Path` is created outside of the BaGet top-level directory. See the [BaGet Folder Permissions](#baget-folder-permissions).
 
 
-## Maximum Published Package Size
+## IIS Server Options
 
-This can be configured for IIS - see [Maximum Published Package Size in IIS](../configuration.md#maximum-published-package-size-in-iis).
+Settings such as the maximum package size can be configured for IIS in the appsettings.json file - see [IIS Server Options](../configuration.md#iis-server-options).

--- a/docs/quickstart/iis-proxy.md
+++ b/docs/quickstart/iis-proxy.md
@@ -42,3 +42,8 @@ Ensure that the configuration's storage `Path` has the appropriate forward slash
 ```
 
 Note that you will need to adjust folder permissions if the `Path` is created outside of the BaGet top-level directory. See the [BaGet Folder Permissions](#baget-folder-permissions).
+
+
+## Maximum Published Package Size
+
+This can be configured for IIS - see [Maximum Published Package Size in IIS](../configuration.md#maximum-published-package-size-in-iis).

--- a/src/BaGet/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet/Extensions/IServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using BaGet.Gcp.Configuration;
 using BaGet.Gcp.Extensions;
 using BaGet.Gcp.Services;
 using BaGet.Protocol;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,7 @@ namespace BaGet.Extensions
             services.ConfigureAws(configuration);
             services.ConfigureGcp(configuration);
             services.ConfigureAliyunOSS(configuration);
+            services.ConfigureIis(configuration);
 
             if (httpServices)
             {
@@ -188,6 +190,15 @@ namespace BaGet.Extensions
             IConfiguration configuration)
         {
             services.ConfigureAndValidate<GoogleCloudStorageOptions>(configuration.GetSection(nameof(BaGetOptions.Storage)));
+
+            return services;
+        }
+        
+        public static IServiceCollection ConfigureIis(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.ConfigureAndValidate<IISServerOptions>(configuration.GetSection(nameof(IISServerOptions)));
 
             return services;
         }

--- a/src/BaGet/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet/Extensions/IServiceCollectionExtensions.cs
@@ -198,6 +198,11 @@ namespace BaGet.Extensions
             this IServiceCollection services,
             IConfiguration configuration)
         {
+            services.Configure<IISServerOptions>(iis =>
+            {
+                iis.MaxRequestBodySize = 262144000;
+            });
+
             services.ConfigureAndValidate<IISServerOptions>(configuration.GetSection(nameof(IISServerOptions)));
 
             return services;

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -22,10 +22,6 @@
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
 
-  "IISServerOptions": {
-    "MaxRequestBodySize": 262144000
-  },
-
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -22,6 +22,10 @@
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
 
+  "IISServerOptions": {
+    "MaxRequestBodySize": 262144000
+  },
+
   "Logging": {
     "IncludeScopes": false,
     "Debug": {


### PR DESCRIPTION
Now sets the MaxRequestBodySize for IIS on startup.

 * I've modified the startup code to set the IISServerOptions based on configuration in the appsettings.json file, with a default entry for MaxRequestBodySize with a maximum size of 250MB.
 * I've updated the documentation

Addresses https://github.com/loic-sharma/BaGet/issues/463
