### PR TITLE
[Client SDK] Reduce dependencies

### DIFF
--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -10,7 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/BaGet.Protocol/Extensions/CatalogModelExtensions.cs
+++ b/src/BaGet.Protocol/Extensions/CatalogModelExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using BaGet.Protocol.Models;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace BaGet.Protocol
@@ -36,7 +35,11 @@ namespace BaGet.Protocol
             if (excludeRedundantLeaves)
             {
                 leaves = leaves
-                    .GroupBy(x => new PackageIdentity(x.PackageId, x.ParsePackageVersion()))
+                    .GroupBy(x => new
+                    {
+                        PackageId = x.PackageId.ToLowerInvariant(),
+                        PackageVersion = x.ParsePackageVersion()
+                    })
                     .Select(x => x.Last())
                     .OrderBy(x => x.CommitTimestamp);
             }

--- a/src/BaGet.Protocol/Search/RawSearchClient.cs
+++ b/src/BaGet.Protocol/Search/RawSearchClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGet.Protocol.Models;
@@ -81,9 +80,9 @@ namespace BaGet.Protocol.Internal
             foreach (var parameter in queryString)
             {
                 builder.Append(hasQuery ? '&' : '?');
-                builder.Append(UrlEncoder.Default.Encode(parameter.Key));
+                builder.Append(Uri.EscapeDataString(parameter.Key));
                 builder.Append('=');
-                builder.Append(UrlEncoder.Default.Encode(parameter.Value));
+                builder.Append(Uri.EscapeDataString(parameter.Value));
                 hasQuery = true;
             }
 


### PR DESCRIPTION
No longer depend on `NuGet.Protocol` as that depends on the dynamic runtime, which itself has a large dependency graph.