### PR TITLE
Fix request pipeline for custom PathBase settings

### DIFF
--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -43,12 +43,13 @@ namespace BaGet
                 app.UseStatusCodePages();
             }
 
+            app.UseForwardedHeaders();
+            app.UsePathBase(options.PathBase);
+
             app.UseSpaStaticFiles();
 
             app.UseRouting();
 
-            app.UseForwardedHeaders();
-            app.UsePathBase(options.PathBase);
             app.UseCors(ConfigureCorsOptions.CorsPolicy);
             app.UseOperationCancelledMiddleware();
 


### PR DESCRIPTION
Summary of the changes

 * `UsePathBase` only works if applied before any file servers
 * This is just a quick fix before #388 is merged
