### PR TITLE
Added a file to build Docker ARMv7 image

### DIFF
--- a/Dockerfile-armv7
+++ b/Dockerfile-armv7
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-bionic-arm32v7 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
+WORKDIR /src
+COPY /src .
+RUN dotnet restore BaGet
+RUN dotnet build BaGet -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish BaGet -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+ENTRYPOINT ["dotnet", "BaGet.dll"]


### PR DESCRIPTION
Added a Docker file to build an ARMv7 image

 * Allows to use dockerized image on a variety of armv7 SoC systems

build could be started with ` docker build -f Dockerfile-armv7 -t baget-armv7 .`
