### PR TITLE
Let environment variables overwrite configuration file settings

### DIFF
--- a/src/BaGet/Extensions/IHostBuilderExtensions.cs
+++ b/src/BaGet/Extensions/IHostBuilderExtensions.cs
@@ -12,11 +12,10 @@ namespace BaGet.Extensions
         {
             return builder.ConfigureAppConfiguration((context, config) =>
             {
-                config.AddEnvironmentVariables();
-
                 config
                     .SetBasePath(Environment.CurrentDirectory)
-                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddEnvironmentVariables();
 
                 if (args != null)
                 {


### PR DESCRIPTION
In case of ambiguity, environment variables are overwritten by configuration file settings, this should be the other way around. (Environment variables should have a higher priority.)

This PR changes the order of applying configuration variables. 
