### PR TITLE
Normalize icon entry path prior to extraction

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging;
 
 namespace BaGet.Core
@@ -51,7 +52,9 @@ namespace BaGet.Core
             this PackageArchiveReader package,
             CancellationToken cancellationToken)
         {
-            return await package.GetStreamAsync(package.NuspecReader.GetIcon(), cancellationToken);
+            return await package.GetStreamAsync(
+                PathUtility.StripLeadingDirectorySeparators(package.NuspecReader.GetIcon()),
+                cancellationToken);
         }
 
         public static Package GetPackageMetadata(this PackageArchiveReader packageReader)


### PR DESCRIPTION
This package cannot be pushed to BaGet on Linux: https://www.nuget.org/packages/Microsoft.Build.NoTargets/1.0.88

This is because the .nuspec has a back slash `\` for the icon path. This works just fine on nuget.org (normalization is in place) and BaGet on Windows (both slashes are acceptable). Forward slash on Linux also works fine.

This is the API that NuGetGallery uses:
https://github.com/NuGet/NuGetGallery/blob/5b7c505086fae24912f3b0d3df58ffb5a9d1e8b8/src/NuGetGallery.Core/Services/FIleNameHelper.cs#L81

The error message is:
```
System.IO.FileNotFoundException: images\MSBuild-NuGet-Icon.png
   at NuGet.Packaging.ZipArchiveExtensions.LookupEntry(ZipArchive zipArchive, String path)
   at NuGet.Packaging.ZipArchiveExtensions.OpenFile(ZipArchive zipArchive, String path)
   at NuGet.Packaging.PackageArchiveReader.GetStream(String path)
   at NuGet.Packaging.PackageReaderBase.GetStreamAsync(String path, CancellationToken cancellationToken)
   at BaGet.Core.PackageArchiveReaderExtensions.GetIconAsync(PackageArchiveReader package, CancellationToken cancellationToken) in /home/joel/BaGet/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs:line 54
   at BaGet.Core.PackageIndexingService.IndexAsync(Stream packageStream, CancellationToken cancellationToken) in /home/joel/BaGet/src/BaGet.Core/Indexing/PackageIndexingService.cs:line 61
```