### PR TITLE
Ensures that the registration index is sorted by version

### DIFF
--- a/src/BaGet.Core/Metadata/RegistrationBuilder.cs
+++ b/src/BaGet.Core/Metadata/RegistrationBuilder.cs
@@ -16,7 +16,7 @@ namespace BaGet.Core
 
         public virtual BaGetRegistrationIndexResponse BuildIndex(PackageRegistration registration)
         {
-            var versions = registration.Packages.Select(p => p.Version).ToList();
+            var sortedPackages = registration.Packages.OrderBy(p => p.Version).ToList();
 
             // TODO: Paging of registration items.
             // "Un-paged" example: https://api.nuget.org/v3/registration3/newtonsoft.json/index.json
@@ -33,9 +33,9 @@ namespace BaGet.Core
                     {
                         RegistrationPageUrl = _url.GetRegistrationIndexUrl(registration.PackageId),
                         Count = registration.Packages.Count(),
-                        Lower = versions.Min().ToNormalizedString().ToLowerInvariant(),
-                        Upper = versions.Max().ToNormalizedString().ToLowerInvariant(),
-                        ItemsOrNull = registration.Packages.Select(ToRegistrationIndexPageItem).ToList(),
+                        Lower = sortedPackages.First().Version.ToNormalizedString().ToLowerInvariant(),
+                        Upper = sortedPackages.Last().Version.ToNormalizedString().ToLowerInvariant(),
+                        ItemsOrNull = sortedPackages.Select(ToRegistrationIndexPageItem).ToList(),
                     }
                 }
             };

--- a/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
+++ b/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NuGet.Versioning;
+using Xunit;
+
+namespace BaGet.Core.Tests.Metadata
+{
+    public class RegistrationBuilderTests
+    {
+        private readonly Mock<IUrlGenerator> _urlGenerator;
+
+        public RegistrationBuilderTests()
+        {
+            _urlGenerator = new Mock<IUrlGenerator>();
+        }
+
+        [Fact]
+        public void TheRegistrationIndexResponseIsSortedByVersion()
+        {
+            // Arrange
+            var packageId = "BaGet.Test";
+            var authors = new string[] { "test" };
+
+            var packages = new List<Package>
+            {
+                GetTestPackage(packageId, "3.1.0"),
+                GetTestPackage(packageId, "10.0.5"),
+                GetTestPackage(packageId, "3.2.0"),
+                GetTestPackage(packageId, "3.1.0-pre"),
+                GetTestPackage(packageId, "1.0.0-beta1"),
+                GetTestPackage(packageId, "1.0.0"),
+            };
+
+            var registration = new PackageRegistration(packageId, packages);
+
+            var registrationBuilder = new RegistrationBuilder(_urlGenerator.Object);
+
+            // Act
+            var response = registrationBuilder.BuildIndex(registration);
+
+            // Assert
+            Assert.Equal(packages.Count, response.Pages[0].ItemsOrNull.Count);
+            var index = 0;
+            foreach (var package in packages.OrderBy(p => p.Version))
+            {
+                Assert.Equal(package.Version.ToFullString(), response.Pages[0].ItemsOrNull[index++].PackageMetadata.Version);
+            }
+        }
+
+        /// <summary>
+        /// Create a fake <see cref="Package"></see> with the minimum metadata needed by the <see cref="RegistrationBuilder"></see>.
+        /// </summary>
+        private Package GetTestPackage(string packageId, string version)
+        {            
+            return new Package
+            {
+                Id = packageId,
+                Authors = new string[] { "test" },
+                PackageTypes = new List<PackageType> { new PackageType { Name = "test" } },
+                Dependencies = new List<PackageDependency> { },
+                Version = new NuGetVersion(version),
+            };
+        }
+    }
+}


### PR DESCRIPTION
The registration index is ordered by version as expected by the UI.

Fixes #534 
