### PR TITLE
Fixed copyright year on the documentation page.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_url: https://loic-sharma.github.io/BaGet/
 repo_name: loic-sharma/BaGet
 repo_url: https://github.com/loic-sharma/BaGet
 
-copyright: 'Copyright &copy; 2018 Loic Sharma'
+copyright: 'Copyright &copy; 2020 Loic Sharma'
 
 theme:
   name: material


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Updated copyright year on the documentation page from 2018 to 2020.

Just a small fix, so I don't want to add an issue for this ;)