### PR TITLE
Update the bindings in docker quickstart

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -35,7 +35,7 @@ docker pull loicsharma/baget
 You can now run BaGet:
 
 ```
-docker run --rm --name nuget-server -p 5555:80 --env-file baget.env -v "$(pwd)/baget-data:/var/baget" loicsharma/baget:latest
+docker run --rm --name nuget-server -p 5555:5000 --env-file baget.env -v "$(pwd)/baget-data:/var/baget" loicsharma/baget:latest
 ```
 
 ## Publish Packages


### PR DESCRIPTION
Update the bindings in docker quickstart

 * When running in a docker container and without changing any aspnetcore binding, the default port is `5000` and not `80` as mentionned in the documentation.

