### PR TITLE
Fix URL configuration issues

### DIFF
--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -76,19 +76,6 @@ namespace BaGet
                         options.Limits.MaxRequestBodySize = null;
                     });
 
-                    var config = new ConfigurationBuilder()
-                        .SetBasePath(Directory.GetCurrentDirectory())
-                        .AddJsonFile("appsettings.json", optional: true)
-                        .AddCommandLine(args)
-                        .Build();
-
-                    var urls = config["Urls"];
-
-                    if (!string.IsNullOrWhiteSpace(urls))
-                    {
-                        web.UseUrls(urls);
-                    }
-
                     web.UseStartup<Startup>();
                 });
         }

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -45,7 +45,7 @@ namespace BaGet
                 });
             });
 
-            app.Option("--urls", "The URL that BaGet should bind to.", CommandOptionType.SingleValue);
+            app.Option("--urls", "The URLs that BaGet should bind to.", CommandOptionType.SingleValue);
 
             app.OnExecuteAsync(async cancellationToken =>
             {

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -45,6 +45,8 @@ namespace BaGet
                 });
             });
 
+            app.Option("--urls", "The URL that BaGet should bind to.", CommandOptionType.SingleValue);
+
             app.OnExecuteAsync(async cancellationToken =>
             {
                 await host.RunMigrationsAsync(cancellationToken);

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -1,6 +1,5 @@
 {
   "ApiKey": "",
-  "Urls": "http://*:5000",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
 
@@ -22,6 +21,16 @@
     "Enabled": false,
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
+
+  // Uncomment this to configure BaGet to listen to port 8080.
+  // See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#listenoptionsusehttps
+  //"Kestrel": {
+  //  "Endpoints": {
+  //    "Http": {
+  //      "Url": "http://localhost:8080"
+  //    }
+  //  }
+  //},
 
   "Logging": {
     "IncludeScopes": false,


### PR DESCRIPTION
Fixes https://github.com/loic-sharma/BaGet/issues/548

Sadly the `urls` config is no longer as clean as @SeppPenner's change. However, this solution works with Docker scenarios. In the future I'll consider how to bring back the `Urls` top-level config without breaking Docker.

I also added the `--urls` option to mirror ASP.NET Core. For more information, see: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#endpoint-configuration

/cc @ffandreassoroko
/cc @SeppPenner 