### PR TITLE
Add integration tests

### DIFF
--- a/src/BaGet.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGet.Core/Extensions/DependencyInjectionExtensions.cs
@@ -78,6 +78,7 @@ namespace BaGet.Core
             services.TryAddSingleton<NullSearchIndexer>();
             services.TryAddSingleton<NullSearchService>();
             services.TryAddSingleton<RegistrationBuilder>();
+            services.TryAddSingleton<SystemTime>();
             services.TryAddSingleton<ValidateStartupOptions>();
 
             services.TryAddSingleton(HttpClientFactory);

--- a/src/BaGet.Core/Extensions/SystemTime.cs
+++ b/src/BaGet.Core/Extensions/SystemTime.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BaGet.Core
+{
+    /// <summary>
+    /// A wrapper that allows for unit tests related to system time.
+    /// </summary>
+    public class SystemTime
+    {
+        public virtual DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/src/BaGet.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGet.Core/Indexing/PackageIndexingService.cs
@@ -13,6 +13,7 @@ namespace BaGet.Core
         private readonly IPackageService _packages;
         private readonly IPackageStorageService _storage;
         private readonly ISearchIndexer _search;
+        private readonly SystemTime _time;
         private readonly IOptionsSnapshot<BaGetOptions> _options;
         private readonly ILogger<PackageIndexingService> _logger;
 
@@ -20,12 +21,14 @@ namespace BaGet.Core
             IPackageService packages,
             IPackageStorageService storage,
             ISearchIndexer search,
+            SystemTime time,
             IOptionsSnapshot<BaGetOptions> options,
             ILogger<PackageIndexingService> logger)
         {
             _packages = packages ?? throw new ArgumentNullException(nameof(packages));
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _search = search ?? throw new ArgumentNullException(nameof(search));
+            _time = time ?? throw new ArgumentNullException(nameof(time));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -43,6 +46,8 @@ namespace BaGet.Core
                 using (var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
                 {
                     package = packageReader.GetPackageMetadata();
+                    package.Published = _time.UtcNow;
+
                     nuspecStream = await packageReader.GetNuspecAsync(cancellationToken);
                     nuspecStream = await nuspecStream.AsTemporaryFileStreamAsync();
 

--- a/src/BaGet.Protocol/NuGetClient.cs
+++ b/src/BaGet.Protocol/NuGetClient.cs
@@ -63,6 +63,7 @@ namespace BaGet.Protocol
             _contentClient = clientFactory.CreatePackageContentClient();
             _metadataClient = clientFactory.CreatePackageMetadataClient();
             _searchClient = clientFactory.CreateSearchClient();
+            _autocompleteClient = clientFactory.CreateAutocompleteClient();
         }
 
         /// <summary>
@@ -157,7 +158,9 @@ namespace BaGet.Protocol
         /// <param name="packageId">The package ID.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>The package's listed versions, if any.</returns>
-        public virtual async Task<IReadOnlyList<NuGetVersion>> ListPackageVersionsAsync(string packageId, CancellationToken cancellationToken)
+        public virtual async Task<IReadOnlyList<NuGetVersion>> ListPackageVersionsAsync(
+            string packageId,
+            CancellationToken cancellationToken = default)
         {
             // TODO: Use the Autocomplete's enumerate versions endpoint if this is not Sleet.
             var packages = await GetPackageMetadataAsync(packageId, cancellationToken);

--- a/tests/BaGet.Core.Tests/Services/PackageIndexingServiceTests.cs
+++ b/tests/BaGet.Core.Tests/Services/PackageIndexingServiceTests.cs
@@ -11,6 +11,7 @@ namespace BaGet.Core.Tests.Services
         private readonly Mock<IPackageService> _packages;
         private readonly Mock<IPackageStorageService> _storage;
         private readonly Mock<ISearchIndexer> _search;
+        private readonly Mock<SystemTime> _time;
         private readonly PackageIndexingService _target;
 
         public PackageIndexingServiceTests()
@@ -18,11 +19,13 @@ namespace BaGet.Core.Tests.Services
             _packages = new Mock<IPackageService>();
             _storage = new Mock<IPackageStorageService>();
             _search = new Mock<ISearchIndexer>();
+            _time = new Mock<SystemTime>();
 
             _target = new PackageIndexingService(
                 _packages.Object,
                 _storage.Object,
                 _search.Object,
+                _time.Object,
                 Mock.Of<IOptionsSnapshot<BaGetOptions>>(),
                 Mock.Of<ILogger<PackageIndexingService>>());
         }

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -1,7 +1,9 @@
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +23,7 @@ namespace BaGet.Tests
         [Fact]
         public async Task IndexReturnsOk()
         {
-            var response = await _client.GetAsync("v3/index.json");
+            using var response = await _client.GetAsync("v3/index.json");
             var content = await response.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -29,11 +31,269 @@ namespace BaGet.Tests
         }
 
         [Fact]
+        public async Task SearchReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/search");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""@base"": ""http://localhost/v3/registration""
+  },
+  ""totalHits"": 1,
+  ""data"": [
+    {
+      ""id"": ""DefaultPackage"",
+      ""version"": ""1.2.3"",
+      ""description"": ""Default package description"",
+      ""authors"": [
+        ""Default package author""
+      ],
+      ""iconUrl"": """",
+      ""licenseUrl"": """",
+      ""projectUrl"": """",
+      ""registration"": ""http://localhost/v3/registration/defaultpackage/index.json"",
+      ""summary"": """",
+      ""tags"": [],
+      ""title"": """",
+      ""totalDownloads"": 0,
+      ""versions"": [
+        {
+          ""@id"": ""http://localhost/v3/registration/defaultpackage/1.2.3.json"",
+          ""version"": ""1.2.3"",
+          ""downloads"": 0
+        }
+      ]
+    }
+  ]
+}", json);
+        }
+
+        [Fact]
+        public async Task SearchReturnsEmpty()
+        {
+            using var response = await _client.GetAsync("v3/search?q=PackageDoesNotExist");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""@base"": ""http://localhost/v3/registration""
+  },
+  ""totalHits"": 0,
+  ""data"": []
+}", json);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/autocomplete");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#""
+  },
+  ""totalHits"": 1,
+  ""data"": [
+    ""DefaultPackage""
+  ]
+}", json);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsEmpty()
+        {
+            using var response = await _client.GetAsync("v3/autocomplete?q=PackageDoesNotExist");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#""
+  },
+  ""totalHits"": 0,
+  ""data"": []
+}", json);
+        }
+
+        [Fact]
+        public async Task VersionListReturnsOk()
+        {
+            var response = await _client.GetAsync("v3/package/DefaultPackage/index.json");
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{""versions"":[""1.2.3""]}", content);
+        }
+
+        [Fact]
         public async Task VersionListReturnsNotFound()
         {
-            var response = await _client.GetAsync("v3/package/PackageDoesNotExist/index.json");
+            using var response = await _client.GetAsync("v3/package/PackageDoesNotExist/index.json");
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PackageDownloadReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/package/DefaultPackage/1.2.3/DefaultPackage.1.2.3.nupkg");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PackageDownloadReturnsNotFound()
+        {
+            using var response = await _client.GetAsync(
+                "v3/package/PackageDoesNotExist/1.0.0/PackageDoesNotExist.1.0.0.nupkg");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task NuspecDownloadReturnsOk()
+        {
+            using var response = await _client.GetAsync(
+                "v3/package/DefaultPackage/1.2.3/DefaultPackage.1.2.3.nuspec");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task NuspecDownloadReturnsNotFound()
+        {
+            using var response = await _client.GetAsync(
+                "v3/package/PackageDoesNotExist/1.0.0/PackageDoesNotExist.1.0.0.nuspec");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/registration/DefaultPackage/index.json");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""totalDownloads"": 0,
+  ""@id"": ""http://localhost/v3/registration/defaultpackage/index.json"",
+  ""@type"": [
+    ""catalog:CatalogRoot"",
+    ""PackageRegistration"",
+    ""catalog:Permalink""
+  ],
+  ""count"": 1,
+  ""items"": [
+    {
+      ""@id"": ""http://localhost/v3/registration/defaultpackage/index.json"",
+      ""count"": 1,
+      ""items"": [
+        {
+          ""@id"": ""http://localhost/v3/registration/defaultpackage/1.2.3.json"",
+          ""catalogEntry"": {
+            ""downloads"": 0,
+            ""hasReadme"": false,
+            ""packageTypes"": [
+              ""Dependency""
+            ],
+            ""releaseNotes"": """",
+            ""repositoryUrl"": """",
+            ""repositoryType"": null,
+            ""@id"": null,
+            ""id"": ""DefaultPackage"",
+            ""version"": ""1.2.3"",
+            ""authors"": ""Default package author"",
+            ""dependencyGroups"": [],
+            ""deprecation"": null,
+            ""description"": ""Default package description"",
+            ""iconUrl"": """",
+            ""language"": """",
+            ""licenseUrl"": """",
+            ""listed"": true,
+            ""minClientVersion"": """",
+            ""packageContent"": ""http://localhost/v3/package/defaultpackage/1.2.3/defaultpackage.1.2.3.nupkg"",
+            ""projectUrl"": """",
+            ""published"": ""2020-01-01T00:00:00Z"",
+            ""requireLicenseAcceptance"": false,
+            ""summary"": """",
+            ""tags"": [],
+            ""title"": """"
+          },
+          ""packageContent"": ""http://localhost/v3/package/defaultpackage/1.2.3/defaultpackage.1.2.3.nupkg""
+        }
+      ],
+      ""lower"": ""1.2.3"",
+      ""upper"": ""1.2.3""
+    }
+  ]
+}", json);
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsNotFound()
+        {
+            using var response = await _client.GetAsync("v3/registration/PackageDoesNotExist/index.json");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PackageMetadataLeafReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/registration/DefaultPackage/1.2.3.json");
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""downloads"": 0,
+  ""@id"": ""http://localhost/v3/registration/defaultpackage/1.2.3.json"",
+  ""@type"": [
+    ""Package"",
+    ""http://schema.nuget.org/catalog#Permalink""
+  ],
+  ""listed"": true,
+  ""packageContent"": ""http://localhost/v3/package/defaultpackage/1.2.3/defaultpackage.1.2.3.nupkg"",
+  ""published"": ""2020-01-01T00:00:00Z"",
+  ""registration"": ""http://localhost/v3/registration/defaultpackage/index.json""
+}", json);
+        }
+
+        [Fact]
+        public async Task PackageMetadataLeafReturnsNotFound()
+        {
+            using var response = await _client.GetAsync("v3/registration/PackageDoesNotExist/1.0.0.json");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        private string PrettifyJson(Stream jsonStream)
+        {
+            using var writer = new StringWriter();
+            using var jsonWriter = new JsonTextWriter(writer)
+            {
+                Formatting = Formatting.Indented,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc
+            };
+
+            using var reader = new StreamReader(jsonStream);
+            using var jsonReader = new JsonTextReader(reader);
+
+            jsonWriter.WriteToken(jsonReader);
+            return writer.ToString();
         }
     }
 }

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGetClientIntegrationTests.cs
+++ b/tests/BaGet.Tests/BaGetClientIntegrationTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BaGet.Protocol;
+using BaGet.Protocol.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BaGet.Tests
+{
+    /// <summary>
+    /// Uses BaGet's client SDK to interact with the BaGet test host.
+    /// </summary>
+    public class BaGetClientIntegrationTests : IClassFixture<BaGetWebApplicationFactory>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+        private readonly NuGetClientFactory _clientFactory;
+        private readonly NuGetClient _client;
+
+        public BaGetClientIntegrationTests(
+            BaGetWebApplicationFactory factory,
+            ITestOutputHelper output)
+        {
+            _factory = factory.WithOutput(output);
+
+            var serviceIndexUrl = new Uri(_factory.Server.BaseAddress, "v3/index.json");
+
+            var httpClient = _factory.CreateDefaultClient();
+
+            _clientFactory = new NuGetClientFactory(httpClient, serviceIndexUrl.AbsoluteUri);
+            _client = new NuGetClient(_clientFactory);
+        }
+
+        [Fact]
+        public async Task ValidIndex()
+        {
+            var client = _clientFactory.CreateServiceIndexClient();
+            var index = await client.GetAsync();
+
+            Assert.Equal("3.0.0", index.Version);
+            Assert.Equal(12, index.Resources.Count);
+
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "PackageBaseAddress/3.0.0" }));
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "PackagePublish/2.0.0" }));
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "RegistrationsBaseUrl" }));
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "SearchAutocompleteService" }));
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "SearchQueryService" }));
+            Assert.NotEmpty(index.GetResourceUrl(new[] { "SymbolPackagePublish/4.9.0" }));
+        }
+
+        [Fact]
+        public async Task SearchReturnsResults()
+        {
+            var results = await _client.SearchAsync();
+
+            var result = Assert.Single(results);
+            var author = Assert.Single(result.Authors);
+            var version = Assert.Single(result.Versions);
+
+            Assert.Equal("DefaultPackage", result.PackageId);
+            Assert.Equal("1.2.3", result.Version);
+            Assert.Equal("Default package description", result.Description);
+            Assert.Equal("Default package author", author);
+            Assert.Equal(0, result.TotalDownloads);
+
+            Assert.Equal("1.2.3", version.Version);
+            Assert.Equal(0, version.Downloads);
+        }
+
+        [Fact]
+        public async Task SearchReturnsEmpty()
+        {
+            var results = await _client.SearchAsync("PackageDoesNotExist");
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsResults()
+        {
+            var results = await _client.AutocompleteAsync();
+
+            var result = Assert.Single(results);
+
+            Assert.Equal("DefaultPackage", result);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsEmpty()
+        {
+            var results = await _client.AutocompleteAsync("PackageDoesNotExist");
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public async Task VersionListReturnsResults()
+        {
+            var versions = await _client.ListPackageVersionsAsync("DefaultPackage");
+
+            var version = Assert.Single(versions);
+
+            Assert.Equal("1.2.3", version.ToNormalizedString());
+        }
+
+        [Fact]
+        public async Task VersionListReturnsEmpty()
+        {
+            var versions = await _client.ListPackageVersionsAsync("PackageDoesNotExist");
+
+            Assert.Empty(versions);
+        }
+
+        [Theory]
+        [InlineData("DefaultPackage", "1.0.0", false)]
+        [InlineData("DefaultPackage", "1.2.3", true)]
+        [InlineData("PackageDoesNotExists", "1.0.0", false)]
+        public async Task PackageDownloadWorks(string packageId, string packageVersion, bool exists)
+        {
+            try
+            {
+                var version = NuGetVersion.Parse(packageVersion);
+
+                using var memoryStream = new MemoryStream();
+                using var packageStream = await _client.DownloadPackageAsync(packageId, version);
+
+                await packageStream.CopyToAsync(memoryStream);
+                memoryStream.Position = 0;
+
+                Assert.True(exists);
+                Assert.Equal(exists, memoryStream.Length > 0);
+            }
+            catch (PackageNotFoundException)
+            {
+                Assert.False(exists);
+            }
+        }
+
+        [Theory]
+        [InlineData("DefaultPackage", "1.0.0", false)]
+        [InlineData("DefaultPackage", "1.2.3", true)]
+        [InlineData("PackageDoesNotExists", "1.0.0", false)]
+        public async Task ManifestDownloadWorks(string packageId, string packageVersion, bool exists)
+        {
+            try
+            {
+                var version = NuGetVersion.Parse(packageVersion);
+
+                using var memoryStream = new MemoryStream();
+                using var packageStream = await _client.DownloadPackageManifestAsync(packageId, version);
+
+                await packageStream.CopyToAsync(memoryStream);
+                memoryStream.Position = 0;
+
+                Assert.True(exists);
+                Assert.Equal(exists, memoryStream.Length > 0);
+            }
+            catch (PackageNotFoundException)
+            {
+                Assert.False(exists);
+            }
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsOk()
+        {
+            var packages = await _client.GetPackageMetadataAsync("DefaultPackage");
+
+            var package = Assert.Single(packages);
+
+            Assert.Equal("DefaultPackage", package.PackageId);
+            Assert.Equal("1.2.3", package.Version);
+            Assert.Equal("Default package description", package.Description);
+            Assert.Equal("Default package author", package.Authors);
+            Assert.True(package.Listed);
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsEmty()
+        {
+            var packages = await _client.GetPackageMetadataAsync("PackageDoesNotExist");
+
+            Assert.Empty(packages);
+        }
+    }
+}

--- a/tests/BaGet.Tests/NuGetClientIntegrationTests.cs
+++ b/tests/BaGet.Tests/NuGetClientIntegrationTests.cs
@@ -1,26 +1,31 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace BaGet.Tests
 {
     /// <summary>
-    /// Uses official nuget client packages to talk to test host.
+    /// Uses the official NuGet client to interact with the BaGet test host.
     /// </summary>
     public class NuGetClientIntegrationTests : IClassFixture<BaGetWebApplicationFactory>
     {
         private readonly WebApplicationFactory<Startup> _factory;
         private readonly HttpClient _client;
 
-        private readonly SourceRepository _sourceRepository;
-        private readonly SourceCacheContext _cacheContext;
+        private readonly SourceRepository _repository;
+        private readonly SourceCacheContext _cache;
+        private readonly NuGet.Common.ILogger _logger;
+        private readonly CancellationToken _cancellationToken;
 
         public NuGetClientIntegrationTests(
             BaGetWebApplicationFactory factory,
@@ -36,14 +41,16 @@ namespace BaGet.Tests
             providers.Add(new Lazy<INuGetResourceProvider>(() => new HttpSourceResourceProviderTestHost(_client)));
             providers.AddRange(Repository.Provider.GetCoreV3());
 
-            _sourceRepository = new SourceRepository(packageSource, providers);
-            _cacheContext = new SourceCacheContext() { NoCache = true, MaxAge = new DateTimeOffset(), DirectDownload = true };
+            _repository = new SourceRepository(packageSource, providers);
+            _cache = new SourceCacheContext() { NoCache = true, MaxAge = new DateTimeOffset(), DirectDownload = true };
+            _logger = NuGet.Common.NullLogger.Instance;
+            _cancellationToken = CancellationToken.None;
         }
 
         [Fact]
         public async Task ValidIndex()
         {
-            var index = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var index = await _repository.GetResourceAsync<ServiceIndexResourceV3>();
 
             Assert.Equal(12, index.Entries.Count);
 
@@ -53,6 +60,186 @@ namespace BaGet.Tests
             Assert.NotEmpty(index.GetServiceEntries("SearchAutocompleteService"));
             Assert.NotEmpty(index.GetServiceEntries("SearchQueryService"));
             Assert.NotEmpty(index.GetServiceEntries("SymbolPackagePublish/4.9.0"));
+        }
+
+        [Fact]
+        public async Task SearchReturnsResults()
+        {
+            var resource = await _repository.GetResourceAsync<PackageSearchResource>();
+            var searchFilter = new SearchFilter(includePrerelease: true);
+
+            var results = await resource.SearchAsync(
+                "",
+                searchFilter,
+                skip: 0,
+                take: 20,
+                _logger,
+                _cancellationToken);
+
+            var result = Assert.Single(results);
+
+            Assert.Equal("DefaultPackage", result.Identity.Id);
+            Assert.Equal("1.2.3", result.Identity.Version.ToNormalizedString());
+            Assert.Equal("Default package description", result.Description);
+            Assert.Equal("Default package author", result.Authors);
+            Assert.Equal(0, result.DownloadCount);
+
+            var versions = await result.GetVersionsAsync();
+            var version = Assert.Single(versions);
+
+            Assert.Equal("1.2.3", version.Version.ToNormalizedString());
+            Assert.Equal(0, version.DownloadCount);
+        }
+
+        [Fact]
+        public async Task SearchReturnsEmpty()
+        {
+            var resource = await _repository.GetResourceAsync<PackageSearchResource>();
+            var searchFilter = new SearchFilter(includePrerelease: true);
+
+            var results = await resource.SearchAsync(
+                "PackageDoesNotExist",
+                searchFilter,
+                skip: 0,
+                take: 20,
+                _logger,
+                _cancellationToken);
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsResults()
+        {
+            var resource = await _repository.GetResourceAsync<AutoCompleteResource>();
+            var results = await resource.IdStartsWith(
+                "",
+                includePrerelease: true,
+                _logger,
+                _cancellationToken);
+
+            var result = Assert.Single(results);
+
+            Assert.Equal("DefaultPackage", result);
+        }
+
+        [Fact]
+        public async Task AutocompleteReturnsEmpty()
+        {
+            var resource = await _repository.GetResourceAsync<AutoCompleteResource>();
+            var results = await resource.IdStartsWith(
+                "PackageDoesNotExist",
+                includePrerelease: true,
+                _logger,
+                _cancellationToken);
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public async Task VersionListReturnsResults()
+        {
+            var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+            var versions = await resource.GetAllVersionsAsync(
+                "DefaultPackage",
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            var version = Assert.Single(versions);
+
+            Assert.Equal("1.2.3", version.ToNormalizedString());
+        }
+
+        [Fact]
+        public async Task VersionListReturnsEmpty()
+        {
+            var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+            var versions = await resource.GetAllVersionsAsync(
+                "PackageDoesNotExist",
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            Assert.Empty(versions);
+        }
+
+        [Theory]
+        [InlineData("DefaultPackage", "1.0.0", false)]
+        [InlineData("DefaultPackage", "1.2.3", true)]
+        [InlineData("PackageDoesNotExists", "1.0.0", false)]
+        public async Task PackageExistsWorks(string packageId, string packageVersion, bool exists)
+        {
+            var version = NuGetVersion.Parse(packageVersion);
+            var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+            var result = await resource.DoesPackageExistAsync(
+                packageId,
+                version,
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            Assert.Equal(exists, result);
+        }
+
+        [Theory]
+        [InlineData("DefaultPackage", "1.0.0", false)]
+        [InlineData("DefaultPackage", "1.2.3", true)]
+        [InlineData("PackageDoesNotExists", "1.0.0", false)]
+        public async Task PackageDownloadWorks(string packageId, string packageVersion, bool exists)
+        {
+            using var packageStream = new MemoryStream();
+
+            var version = NuGetVersion.Parse(packageVersion);
+            var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+            var result = await resource.CopyNupkgToStreamAsync(
+                packageId,
+                version,
+                packageStream,
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            packageStream.Position = 0;
+
+            Assert.Equal(exists, result);
+            Assert.Equal(exists, packageStream.Length > 0);
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsOk()
+        {
+            var resource = await _repository.GetResourceAsync<PackageMetadataResource>();
+            var packages = await resource.GetMetadataAsync(
+                "DefaultPackage",
+                includePrerelease: true,
+                includeUnlisted: true,
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            var package = Assert.Single(packages);
+
+            Assert.Equal("DefaultPackage", package.Identity.Id);
+            Assert.Equal("1.2.3", package.Identity.Version.ToNormalizedString());
+            Assert.Equal("Default package description", package.Description);
+            Assert.Equal("Default package author", package.Authors);
+            Assert.True(package.IsListed);
+        }
+
+        [Fact]
+        public async Task PackageMetadataReturnsEmty()
+        {
+            var resource = await _repository.GetResourceAsync<PackageMetadataResource>();
+            var packages = await resource.GetMetadataAsync(
+                "PackageDoesNotExist",
+                includePrerelease: true,
+                includeUnlisted: true,
+                _cache,
+                _logger,
+                _cancellationToken);
+
+            Assert.Empty(packages);
         }
     }
 }

--- a/tests/BaGet.Tests/Support/BaGetWebApplicationFactory.cs
+++ b/tests/BaGet.Tests/Support/BaGetWebApplicationFactory.cs
@@ -6,6 +6,8 @@ using BaGet.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,12 +18,28 @@ namespace BaGet.Tests
 {
     public class BaGetWebApplicationFactory : WebApplicationFactory<Startup>
     {
+        private readonly Mock<SystemTime> _time;
+
+        public BaGetWebApplicationFactory()
+        {
+            _time = new Mock<SystemTime>();
+            _time
+                .Setup(t => t.UtcNow)
+                .Returns(DateTime.Parse("2020-01-01T00:00:00.000Z"));
+        }
+
         public WebApplicationFactory<Startup> WithOutput(ITestOutputHelper output)
         {
             return WithWebHostBuilder(builder =>
             {
                 builder.ConfigureLogging(logging =>
                 {
+                    // BaGet uses console logging by default. This logger throws operation
+                    // cancelled exceptions when the host shuts down, causing the the debugger
+                    // to pause repeatedly if CLR exceptions are enabled.
+                    logging.ClearProviders();
+
+                    // Pipe logs to the xunit output.
                     logging.AddProvider(new XunitLoggerProvider(output));
                 });
             });
@@ -41,6 +59,7 @@ namespace BaGet.Tests
 
             builder
                 .UseStartup<Startup>()
+                .UseEnvironment("Production")
                 .ConfigureAppConfiguration(config =>
                 {
                     // Setup the integration test configuration.
@@ -56,13 +75,8 @@ namespace BaGet.Tests
                 })
                 .ConfigureServices((context, services) =>
                 {
-                    // Clobber BaGet services with test replacements.
-                    var time = new Mock<SystemTime>();
-                    time
-                        .Setup(t => t.UtcNow)
-                        .Returns(DateTime.Parse("2020-01-01T00:00:00.000Z"));
-
-                    services.AddSingleton(time.Object);
+                    // Add mocks for testing purposes.
+                    services.AddSingleton(_time.Object);
 
                     // Setup the integration test database.
                     var provider = services.BuildServiceProvider();
@@ -70,14 +84,22 @@ namespace BaGet.Tests
 
                     using (var scope = scopeFactory.CreateScope())
                     {
+                        // Ensure the database is created before we run migrations. The migrations
+                        // can create the database too, however, migrations check whether the database exists
+                        // first. The SQLite provider implements this by attempting to open a connection,
+                        // and if that fails, creating the database. This throws several exceptions that
+                        // pauses the debugger repeatedly if CLR exceptions are enabled.
+                        // See: https://github.com/dotnet/efcore/blob/644d3c8c3a604fd0121d90eaf34f14870e19bcff/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs#L88-L98
                         var ctx = scope.ServiceProvider.GetRequiredService<IContext>();
-                        var indexer = scope.ServiceProvider.GetRequiredService<IPackageIndexingService>();
-                        var cancellationToken = CancellationToken.None;
+                        var dbCreator = ctx.Database.GetService<IRelationalDatabaseCreator>();
 
-                        // Ensure the database is created.
+                        dbCreator.Create();
                         ctx.Database.Migrate();
 
                         // Seed the application with test data.
+                        var indexer = scope.ServiceProvider.GetRequiredService<IPackageIndexingService>();
+                        var cancellationToken = CancellationToken.None;
+
                         var result = indexer.IndexAsync(PackageData.Default, cancellationToken).Result;
                         if (result != PackageIndexingResult.Success)
                         {

--- a/tests/BaGet.Tests/Support/PackageData.cs
+++ b/tests/BaGet.Tests/Support/PackageData.cs
@@ -7,6 +7,8 @@ namespace BaGet.Tests
 {
     public class PackageData
     {
+        private static readonly byte[] DefaultBytes;
+
         static PackageData()
         {
             var builder = new PackageBuilder();
@@ -21,10 +23,13 @@ namespace BaGet.Tests
                 TargetPath = "lib/netstandard2.0/_._"
             });
 
-            Default = new MemoryStream();
-            builder.Save(Default);
+            using var defaultStream = new MemoryStream();
+            builder.Save(defaultStream);
+
+            DefaultBytes = defaultStream.ToArray();
         }
 
-        public static Stream Default { get; }
+        // Create a new stream each time so that tests can run concurrently.
+        public static Stream Default => new MemoryStream(DefaultBytes, writable: false);
     }
 }

--- a/tests/BaGet.Tests/Support/PackageData.cs
+++ b/tests/BaGet.Tests/Support/PackageData.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.IO;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+namespace BaGet.Tests
+{
+    public class PackageData
+    {
+        static PackageData()
+        {
+            var builder = new PackageBuilder();
+
+            builder.Id = "DefaultPackage";
+            builder.Authors.Add("Default package author");
+            builder.Description = "Default package description";
+            builder.Version = NuGetVersion.Parse("1.2.3");
+
+            builder.Files.Add(new PhysicalPackageFile(new MemoryStream())
+            {
+                TargetPath = "lib/netstandard2.0/_._"
+            });
+
+            Default = new MemoryStream();
+            builder.Save(Default);
+        }
+
+        public static Stream Default { get; }
+    }
+}


### PR DESCRIPTION
Add integration tests on the BaGet application to ensure BaGet follows the NuGet protocol. These tests will be used to verify the migration to System.Text.Json and route-to-code (instead of Newtonsoft.Json and controllers).

In the future more integration tests will be added for things like:

1. APIs that modify data (upload, unlist)
1. Custom BaGet endpoints (readme, icon, dependents) 
1. More complex API interactions (search filters, autocomplete filters)