### PR TITLE
change port 5000 to 80

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -35,7 +35,7 @@ docker pull loicsharma/baget
 You can now run BaGet:
 
 ```
-docker run --rm --name nuget-server -p 5555:5000 --env-file baget.env -v "$(pwd)/baget-data:/var/baget" loicsharma/baget:latest
+docker run --rm --name nuget-server -p 5555:80 --env-file baget.env -v "$(pwd)/baget-data:/var/baget" loicsharma/baget:latest
 ```
 
 ## Publish packages


### PR DESCRIPTION
hi 
i want install baGet and  I see run in port 80 not 5000 
I update docker run command

Summary of the changes (in less than 80 chars)

change docker port as 5000 to 80 
https://github.com/loic-sharma/BaGet/issues/563
