### PR TITLE
 Avoid sync-over-async in integration tests

### DIFF
--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -33,6 +33,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task SearchReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync("v3/search");
             var content = await response.Content.ReadAsStreamAsync();
             var json = PrettifyJson(content);
@@ -93,6 +95,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task AutocompleteReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync("v3/autocomplete");
             var content = await response.Content.ReadAsStreamAsync();
             var json = PrettifyJson(content);
@@ -129,6 +133,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task VersionListReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var response = await _client.GetAsync("v3/package/DefaultPackage/index.json");
             var content = await response.Content.ReadAsStringAsync();
 
@@ -147,6 +153,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task PackageDownloadReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync("v3/package/DefaultPackage/1.2.3/DefaultPackage.1.2.3.nupkg");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -164,6 +172,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task NuspecDownloadReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync(
                 "v3/package/DefaultPackage/1.2.3/DefaultPackage.1.2.3.nuspec");
 
@@ -182,6 +192,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task PackageMetadataReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync("v3/registration/DefaultPackage/index.json");
             var content = await response.Content.ReadAsStreamAsync();
             var json = PrettifyJson(content);
@@ -250,6 +262,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task PackageMetadataLeafReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var response = await _client.GetAsync("v3/registration/DefaultPackage/1.2.3.json");
             var content = await response.Content.ReadAsStreamAsync();
             var json = PrettifyJson(content);

--- a/tests/BaGet.Tests/BaGetClientIntegrationTests.cs
+++ b/tests/BaGet.Tests/BaGetClientIntegrationTests.cs
@@ -53,6 +53,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task SearchReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var results = await _client.SearchAsync();
 
             var result = Assert.Single(results);
@@ -80,6 +82,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task AutocompleteReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var results = await _client.AutocompleteAsync();
 
             var result = Assert.Single(results);
@@ -98,6 +102,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task VersionListReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var versions = await _client.ListPackageVersionsAsync("DefaultPackage");
 
             var version = Assert.Single(versions);
@@ -119,6 +125,8 @@ namespace BaGet.Tests
         [InlineData("PackageDoesNotExists", "1.0.0", false)]
         public async Task PackageDownloadWorks(string packageId, string packageVersion, bool exists)
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             try
             {
                 var version = NuGetVersion.Parse(packageVersion);
@@ -144,6 +152,8 @@ namespace BaGet.Tests
         [InlineData("PackageDoesNotExists", "1.0.0", false)]
         public async Task ManifestDownloadWorks(string packageId, string packageVersion, bool exists)
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             try
             {
                 var version = NuGetVersion.Parse(packageVersion);
@@ -166,6 +176,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task PackageMetadataReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var packages = await _client.GetPackageMetadataAsync("DefaultPackage");
 
             var package = Assert.Single(packages);

--- a/tests/BaGet.Tests/NuGetClientIntegrationTests.cs
+++ b/tests/BaGet.Tests/NuGetClientIntegrationTests.cs
@@ -65,6 +65,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task SearchReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var resource = await _repository.GetResourceAsync<PackageSearchResource>();
             var searchFilter = new SearchFilter(includePrerelease: true);
 
@@ -111,6 +113,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task AutocompleteReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var resource = await _repository.GetResourceAsync<AutoCompleteResource>();
             var results = await resource.IdStartsWith(
                 "",
@@ -139,6 +143,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task VersionListReturnsResults()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
             var versions = await resource.GetAllVersionsAsync(
                 "DefaultPackage",
@@ -170,6 +176,8 @@ namespace BaGet.Tests
         [InlineData("PackageDoesNotExists", "1.0.0", false)]
         public async Task PackageExistsWorks(string packageId, string packageVersion, bool exists)
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var version = NuGetVersion.Parse(packageVersion);
             var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
             var result = await resource.DoesPackageExistAsync(
@@ -188,6 +196,8 @@ namespace BaGet.Tests
         [InlineData("PackageDoesNotExists", "1.0.0", false)]
         public async Task PackageDownloadWorks(string packageId, string packageVersion, bool exists)
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             using var packageStream = new MemoryStream();
 
             var version = NuGetVersion.Parse(packageVersion);
@@ -209,6 +219,8 @@ namespace BaGet.Tests
         [Fact]
         public async Task PackageMetadataReturnsOk()
         {
+            await _factory.AddPackageAsync(PackageData.Default);
+
             var resource = await _repository.GetResourceAsync<PackageMetadataResource>();
             var packages = await resource.GetMetadataAsync(
                 "DefaultPackage",

--- a/tests/BaGet.Tests/Support/BaGetWebApplicationFactory.cs
+++ b/tests/BaGet.Tests/Support/BaGetWebApplicationFactory.cs
@@ -104,14 +104,13 @@ namespace BaGet.Tests
         }
     }
 
-    public static class BaGetWebApplicationFactoryExtensions
+    internal static class BaGetWebApplicationFactoryExtensions
     {
         public static async Task AddPackageAsync(
             this WebApplicationFactory<Startup> factory,
             Stream package,
             CancellationToken cancellationToken = default)
         {
-            //PackageData.Default
             var scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
 
             using (var scope = scopeFactory.CreateScope())


### PR DESCRIPTION
The integration tests sporadically deadlock. This removes unnecessary sync-over-async in integration tests to reduce likelihood of deadlocks.