### PR TITLE
Fix multiple author displaying

### DIFF
--- a/src/BaGet.UI/src/SearchResults.test.tsx
+++ b/src/BaGet.UI/src/SearchResults.test.tsx
@@ -35,7 +35,7 @@ describe('Tests for SearchResults component', () => {
       data: [
         {
           id: 'BaGet.Authors',
-          authors: 'BaGet.Authors',
+          authors: ['BaGet.Authors'],
           totalDownloads: 999,
           version: '1.0',
           tags: ['NuGet'],

--- a/src/BaGet.UI/src/SearchResults.tsx
+++ b/src/BaGet.UI/src/SearchResults.tsx
@@ -14,7 +14,7 @@ interface ISearchResultsProps {
 
 interface IPackage {
   id: string;
-  authors: string;
+  authors: string[];
   totalDownloads: number;
   version: string;
   tags: string[];
@@ -196,7 +196,7 @@ class SearchResults extends React.Component<ISearchResultsProps, ISearchResultsS
                 <div className="col-sm-11">
                   <div>
                     <Link to={`/packages/${value.id}`} className="package-title">{value.id}</Link>
-                    <span>by: {value.authors}</span>
+                    <span>by: {value.authors.join(' ')}</span>
                   </div>
                   <ul className="info">
                     <li>


### PR DESCRIPTION
Previously, the author is displayed as `by: author1author2`. This fix make it `by: author1 author2`.