### PR TITLE
Integration Tests for Dependents API

### DIFF
--- a/src/BaGet.Hosting/Controllers/SearchController.cs
+++ b/src/BaGet.Hosting/Controllers/SearchController.cs
@@ -69,9 +69,14 @@ namespace BaGet.Hosting
         }
 
         public async Task<ActionResult<DependentsResponse>> DependentsAsync(
-            [FromQuery] string packageId,
+            [FromQuery] string packageId = null,
             CancellationToken cancellationToken = default)
         {
+            if(string.IsNullOrWhiteSpace(packageId))
+            {
+                return BadRequest();
+            }
+
             return await _searchService.FindDependentsAsync(packageId, cancellationToken);
         }
     }

--- a/src/BaGet.Hosting/Controllers/SearchController.cs
+++ b/src/BaGet.Hosting/Controllers/SearchController.cs
@@ -72,7 +72,7 @@ namespace BaGet.Hosting
             [FromQuery] string packageId = null,
             CancellationToken cancellationToken = default)
         {
-            if(string.IsNullOrWhiteSpace(packageId))
+            if (string.IsNullOrWhiteSpace(packageId))
             {
                 return BadRequest();
             }

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -305,6 +305,14 @@ namespace BaGet.Tests
 }", json);
         }
 
+        [Fact]
+        public async Task PackageDependentsReturnsBadRequest()
+        {
+            using var response = await _client.GetAsync("v3/dependents");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
         private string PrettifyJson(Stream jsonStream)
         {
             using var writer = new StringWriter();

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -290,6 +290,21 @@ namespace BaGet.Tests
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
+        [Fact]
+        public async Task PackageDependentsReturnsOk()
+        {
+            using var response = await _client.GetAsync("v3/dependents?packageId=DefaultPackage");
+
+            var content = await response.Content.ReadAsStreamAsync();
+            var json = PrettifyJson(content);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(@"{
+  ""totalHits"": 0,
+  ""data"": []
+}", json);
+        }
+
         private string PrettifyJson(Stream jsonStream)
         {
             using var writer = new StringWriter();

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -310,7 +310,7 @@ namespace BaGet.Tests
         {
             using var response = await _client.GetAsync("v3/dependents");
 
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         private string PrettifyJson(Stream jsonStream)


### PR DESCRIPTION
Tests that the dependents api:

* Returns OK when packageId=DefaultPackage
* Returns BadRequest when a package ID is not supplied (I implemented this as well, I think it makes sense TBH)

These are my first integration tests ever so let me know how I could improve! I want to add tests for the icon and readme endpoints but I guess you probably want to approve these first before I do that. 