### PR TITLE
Remove unnecessary stream copy in AWS S3 Put

### DIFF
--- a/src/BaGet.Aws/S3StorageService.cs
+++ b/src/BaGet.Aws/S3StorageService.cs
@@ -74,22 +74,15 @@ namespace BaGet.Aws
             // TODO: Uploads should be idempotent. This should fail if and only if the blob
             // already exists but has different content.
 
-            using (var seekableContent = new MemoryStream())
+            await _client.PutObjectAsync(new PutObjectRequest
             {
-                await content.CopyToAsync(seekableContent, 4096, cancellationToken);
-
-                seekableContent.Seek(0, SeekOrigin.Begin);
-
-                await _client.PutObjectAsync(new PutObjectRequest
-                {
-                    BucketName = _bucket,
-                    Key = PrepareKey(path),
-                    InputStream = seekableContent,
-                    ContentType = contentType,
-                    AutoResetStreamPosition = false,
-                    AutoCloseStream = false
-                }, cancellationToken);
-            }
+                BucketName = _bucket,
+                Key = PrepareKey(path),
+                InputStream = content,
+                ContentType = contentType,
+                AutoResetStreamPosition = false,
+                AutoCloseStream = false
+            }, cancellationToken);
 
             return StoragePutResult.Success;
         }


### PR DESCRIPTION
Remove unnecessary copy of package stream during AWS S3 PutAsync

 * Tested locally (local docker, but using S3 storage), with the same offending 200 MB package as reported in the issue.

Addresses https://github.com/loic-sharma/BaGet/issues/594

I ran `docker stats baget` to check the memory usage of the process, and I got
```
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT   MEM %               NET I/O             BLOCK I/O           PIDS
9c57eea5cccc        baget               0.13%               147.8MiB / 1GiB     14.43%              204MB / 206MB       0B / 0B             25
```
So we see that the memory usage went up to only 150 MB, which is quite ok.