### PR TITLE
fix: map different key types to the existing directory structure

### DIFF
--- a/src/BaGet.Core/Storage/SymbolStorageService.cs
+++ b/src/BaGet.Core/Storage/SymbolStorageService.cs
@@ -62,6 +62,8 @@ namespace BaGet.Core
             {
                 throw new ArgumentException(nameof(key));
             }
+            
+            key = key.Substring(0,32) + "ffffffff";
 
             return Path.Combine(
                 SymbolsPathPrefix,


### PR DESCRIPTION
The symbol files are currently stored in directories with the name {key}ffffffff
In order to support incoming symbol requests with the patterns

{key}ffffffff
{key}1
{key}

the keys have to be mapped to the already existing directory structure

Addresses https://github.com/loic-sharma/BaGet/issues/224
