### PR TITLE
Feat add support for Baidu Cloud BOS Storage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ You can run BaGet on your preferred platform:
 * [AWS](installation/aws.md)
 * [Google Cloud](installation/gcp.md)
 * [Alibaba Cloud (Aliyun)](installation/aliyun.md)
+* [Baidu Cloud (Bce)](installation/bce.md)
 
 ## BaGet SDK
 

--- a/docs/installation/bce.md
+++ b/docs/installation/bce.md
@@ -1,0 +1,28 @@
+# Use Bce (Baidu Cloud) Object Storage Service
+
+You can store packages to [Bce (Baidu Cloud) BOS](https://cloud.baidu.com/doc/BOS/index.html).
+
+## Configure BaGet
+
+You can modify BaGet's configurations by editing the `appsettings.json` file. For the full list of configurations, please refer to [BaGet's configuration](../configuration.md) guide.
+
+### Bce BOS Storage
+
+Update the `appsettings.json` file:
+
+```json
+{
+    ...
+
+    "Storage": {
+        "Type": "BceBos",
+        "Endpoint": "http://su.bcebos.com",
+        "Bucket": "foo",
+        "AccessKey": "",
+        "AccessKeySecret": "",
+        "Prefix": "lib/baget" // optional
+    },
+
+    ...
+}
+```

--- a/src/BaGet.Bce/BaGet.Bce.csproj
+++ b/src/BaGet.Bce/BaGet.Bce.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageTags>NuGet;BceSdk;Cloud</PackageTags>
+    <Description>The libraries to host BaGet on Baidu Cloud (BOS).</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BceSdkDotNetCore" Version="1.0.2.911" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BaGet.Core\BaGet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BaGet.Bce/BceApplicationExtensions.cs
+++ b/src/BaGet.Bce/BceApplicationExtensions.cs
@@ -1,0 +1,51 @@
+using System;
+using BaGet.Core;
+using BaGet.Bce;
+using BaiduBce;
+using BaiduBce.Auth;
+using BaiduBce.Services.Bos;
+using BaiduBce.Services.Bos.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace BaGet
+{
+    public static class BceApplicationExtensions
+    {
+        public static BaGetApplication AddBceBosStorage(this BaGetApplication app)
+        {
+            app.Services.AddBaGetOptions<BceStorageOptions>(nameof(BaGetOptions.Storage));
+
+            app.Services.AddTransient<BceStorageService>();
+            app.Services.TryAddTransient<IStorageService>(provider => provider.GetRequiredService<BceStorageService>());
+
+            app.Services.AddSingleton(provider =>
+            {
+                var options = provider.GetRequiredService<IOptions<BceStorageOptions>>().Value;
+                BceClientConfiguration config = new BceClientConfiguration();
+                config.Credentials = new DefaultBceCredentials(options.AccessKey, options.AccessKeySecret);
+                config.Endpoint = options.Endpoint;
+                return new BosClient(config);
+            });
+
+            app.Services.AddProvider<IStorageService>((provider, config) =>
+            {
+                if (!config.HasStorageType("BceBos")) return null;
+
+                return provider.GetRequiredService<BceStorageService>();
+            });
+
+            return app;
+        }
+
+        public static BaGetApplication AddBceBosStorage(
+            this BaGetApplication app,
+            Action<BceStorageOptions> configure)
+        {
+            app.AddBceBosStorage();
+            app.Services.Configure(configure);
+            return app;
+        }
+    }
+}

--- a/src/BaGet.Bce/BceStorageOptions.cs
+++ b/src/BaGet.Bce/BceStorageOptions.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BaGet.Bce
+{
+    public class BceStorageOptions
+    {
+        [Required]
+        public string AccessKey { get; set; }
+
+        [Required]
+        public string AccessKeySecret { get; set; }
+
+        [Required]
+        public string Endpoint { get; set; }
+
+        [Required]
+        public string Bucket { get; set; }
+
+        public string Prefix { get; set; }
+    }
+}

--- a/src/BaGet.Bce/BceStorageService.cs
+++ b/src/BaGet.Bce/BceStorageService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BaiduBce;
+using BaiduBce.Auth;
+using BaiduBce.Services.Bos;
+using BaiduBce.Services.Bos.Model;
+using BaGet.Core;
+using Microsoft.Extensions.Options;
+
+namespace BaGet.Bce
+{
+    public class BceStorageService : IStorageService
+    {
+        private const string Separator = "/";
+        private readonly string _bucket;
+        private readonly string _prefix;
+        private readonly BosClient _client;
+
+        public BceStorageService(IOptionsSnapshot<BceStorageOptions> options, BosClient client)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            _bucket = options.Value.Bucket;
+            _prefix = options.Value.Prefix;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+
+            if (!string.IsNullOrEmpty(_prefix) && !_prefix.EndsWith(Separator))
+                _prefix += Separator;
+        }
+
+        private string PrepareKey(string path)
+        {
+            return _prefix + path.Replace("\\", Separator);
+        }
+
+        public Task<Stream> GetAsync(string path, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var bosObject = _client.GetObject(_bucket, PrepareKey(path));
+                return Task.FromResult(bosObject.ObjectContent);
+            }
+            catch (Exception)
+            {
+                // TODO
+                throw;
+            }
+        }
+
+        public Task<Uri> GetDownloadUriAsync(string path, CancellationToken cancellationToken = default)
+        {
+            var uri = _client.GeneratePresignedUrl(_bucket, PrepareKey(path), 1800);
+
+            return Task.FromResult(uri);
+        }
+
+        public Task<StoragePutResult> PutAsync(string path, Stream content, string contentType, CancellationToken cancellationToken = default)
+        {
+            // TODO: Uploads should be idempotent. This should fail if and only if the blob
+            // already exists but has different content.
+
+            var metadata = new ObjectMetadata();
+            metadata.ContentType = contentType;
+
+            var putResult = _client.PutObject(_bucket, PrepareKey(path), content, metadata);
+
+            if (!string.IsNullOrEmpty(putResult.ETAG)) {
+                return Task.FromResult(StoragePutResult.Success);
+            } else {
+                return Task.FromResult(StoragePutResult.Conflict);
+            }
+        }
+
+        public Task DeleteAsync(string path, CancellationToken cancellationToken = default)
+        {
+            _client.DeleteObject(_bucket, PrepareKey(path));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\BaGet.Aliyun\BaGet.Aliyun.csproj" />
     <ProjectReference Include="..\BaGet.Aws\BaGet.Aws.csproj" />
     <ProjectReference Include="..\BaGet.Azure\BaGet.Azure.csproj" />
+    <ProjectReference Include="..\BaGet.Bce\BaGet.Bce.csproj" />
     <ProjectReference Include="..\BaGet.Core\BaGet.Core.csproj" />
     <ProjectReference Include="..\BaGet.Database.MySql\BaGet.Database.MySql.csproj" />
     <ProjectReference Include="..\BaGet.Database.PostgreSql\BaGet.Database.PostgreSql.csproj" />

--- a/src/BaGet/ConfigureBaGetOptions.cs
+++ b/src/BaGet/ConfigureBaGetOptions.cs
@@ -39,6 +39,7 @@ namespace BaGet
                 "AliyunOss",
                 "AwsS3",
                 "AzureBlobStorage",
+                "BceBos",
                 "Filesystem",
                 "GoogleCloud",
                 "Null",

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -75,6 +75,7 @@ namespace BaGet
             app.AddAliyunOssStorage();
             app.AddAwsS3Storage();
             app.AddAzureBlobStorage();
+            app.AddBceBosStorage();
             app.AddGoogleCloudStorage();
 
             // Add search providers.

--- a/src/readme.md
+++ b/src/readme.md
@@ -18,6 +18,7 @@ These folders contain database-specific components of BaGet:
 These folders contain cloud-specific components of BaGet:
 
 * `BaGet.Aliyun` - BaGet's Alibaba Cloud(Aliyun) provider.
+* `BaGet.Bce` - BaGet's Baidu Cloud(Bce) provider.
 * `BaGet.Aws` - BaGet's Amazon Web Services provider.
 * `BaGet.Azure` - BaGet's Azure provider.
 * `BaGet.Gcp` - BaGet's Google Cloud Platform provider.


### PR DESCRIPTION

Add support for Baidu Cloud BOS Storage
- Added BaGet.Bce project
- Added new StorageType : BceBos

You can store packages to [Baidu Cloud BOS](https://cloud.baidu.com/product/bos.html).

