### PR TITLE
Minio (S3-Compatible) storage backend

### DIFF
--- a/BaGet.sln
+++ b/BaGet.sln
@@ -50,6 +50,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BaGet.Aliyun", "src\BaGet.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaGetWebApplication", "samples\BaGetWebApplication\BaGetWebApplication.csproj", "{E5AFE55D-0932-46A9-BFA3-C8A034037377}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaGet.Minio", "src\BaGet.Minio\BaGet.Minio.csproj", "{C3039B4B-E7A8-4F8F-B740-5292BF478FDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,10 @@ Global
 		{E5AFE55D-0932-46A9-BFA3-C8A034037377}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5AFE55D-0932-46A9-BFA3-C8A034037377}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5AFE55D-0932-46A9-BFA3-C8A034037377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3039B4B-E7A8-4F8F-B740-5292BF478FDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3039B4B-E7A8-4F8F-B740-5292BF478FDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3039B4B-E7A8-4F8F-B740-5292BF478FDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3039B4B-E7A8-4F8F-B740-5292BF478FDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -146,6 +152,7 @@ Global
 		{16B0D424-BB2F-4C0C-90B0-4F7955326ADF} = {DDEC0736-8169-4834-815E-B78E7CE612A4}
 		{9F7C4F38-D598-42D9-A9F8-962490483B18} = {26A0B557-53FB-4B9A-94C4-BCCF1BDCB0CC}
 		{E5AFE55D-0932-46A9-BFA3-C8A034037377} = {DDEC0736-8169-4834-815E-B78E7CE612A4}
+		{C3039B4B-E7A8-4F8F-B740-5292BF478FDF} = {26A0B557-53FB-4B9A-94C4-BCCF1BDCB0CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1423C027-2C90-417F-8629-2A4CF107C055}

--- a/src/BaGet.Minio/BaGet.Minio.csproj
+++ b/src/BaGet.Minio/BaGet.Minio.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+
+    <PackageTags>NuGet;Minio;Cloud</PackageTags>
+    <Description>Libraries to host BaGet on Minio or other S3 compatible storage</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Minio" Version="3.1.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BaGet.Core\BaGet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BaGet.Minio/MinioApplicationExtensions.cs
+++ b/src/BaGet.Minio/MinioApplicationExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using BaGet.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Minio;
+
+namespace BaGet.Minio
+{
+    public static class MinioApplicationExtensions
+    {
+        public static BaGetApplication AddMinioStorage(this BaGetApplication app)
+        {
+            app.Services.AddBaGetOptions<MinioStorageOptions>(nameof(BaGetOptions.Storage));
+
+            app.Services.AddTransient<MinioStorageService>();
+            app.Services.TryAddTransient<IStorageService>(
+                provider => provider.GetRequiredService<MinioStorageService>());
+
+            app.Services.AddProvider<IStorageService>((provider, config) =>
+                !config.HasStorageType("Minio") ? null : provider.GetRequiredService<MinioStorageService>());
+
+            app.Services.AddSingleton(provider =>
+            {
+                var options = provider.GetRequiredService<IOptions<MinioStorageOptions>>().Value;
+
+                var client = new MinioClient(options.Endpoint, options.AccessKey, options.SecretKey);
+                    // options.Region ?? string.Empty);
+
+                if (options.Secure) client.WithSSL();
+
+                return client;
+            });
+
+            return app;
+        }
+
+        public static BaGetApplication AddMinioStorage(this BaGetApplication app, Action<MinioStorageOptions> configure)
+        {
+            app.AddMinioStorage();
+            app.Services.Configure(configure);
+            return app;
+        }
+    }
+}

--- a/src/BaGet.Minio/MinioApplicationExtensions.cs
+++ b/src/BaGet.Minio/MinioApplicationExtensions.cs
@@ -24,8 +24,8 @@ namespace BaGet.Minio
             {
                 var options = provider.GetRequiredService<IOptions<MinioStorageOptions>>().Value;
 
-                var client = new MinioClient(options.Endpoint, options.AccessKey, options.SecretKey);
-                    // options.Region ?? string.Empty);
+                var client = new MinioClient(options.Endpoint, options.AccessKey, options.SecretKey,
+                    options.Region ?? string.Empty);
 
                 if (options.Secure) client.WithSSL();
 

--- a/src/BaGet.Minio/MinioStorageOptions.cs
+++ b/src/BaGet.Minio/MinioStorageOptions.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using BaGet.Core;
+
+namespace BaGet.Minio
+{
+    public class MinioStorageOptions
+    {
+        /// <summary>
+        /// Gets or sets the user ID that identifies the storage service account
+        /// </summary>
+        [RequiredIf(nameof(SecretKey), null, IsInverted = true)]
+        public string AccessKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password to the storage service account
+        /// </summary>
+        [RequiredIf(nameof(AccessKey), null, IsInverted = true)]
+        public string SecretKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the object storage service
+        /// </summary>
+        [Required]
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the storage bucket
+        /// </summary>
+        [Required]
+        public string Bucket { get; set; }
+
+        /// <summary>
+        /// Gets or sets a prefix to all objects stored on the service
+        /// </summary>
+        public string Prefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional region for the storage provider
+        /// </summary>
+        public string Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether HTTPS support is enabled
+        /// </summary>
+        public bool Secure { get; set; }
+
+    }
+}

--- a/src/BaGet.Minio/MinioStorageService.cs
+++ b/src/BaGet.Minio/MinioStorageService.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGet.Core;
+using Microsoft.Extensions.Options;
+using Minio;
+
+namespace BaGet.Minio
+{
+    public class MinioStorageService : IStorageService
+    {
+        private const string Separator = "/";
+        private readonly string _bucket;
+        private readonly string _prefix;
+        private readonly MinioClient _client;
+
+        public MinioStorageService(IOptionsSnapshot<MinioStorageOptions> options, MinioClient client)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            _bucket = options.Value.Bucket;
+            _prefix = options.Value.Prefix;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+
+            if (!string.IsNullOrEmpty(_prefix) && !_prefix.EndsWith(Separator))
+                _prefix += Separator;
+        }
+
+        private string PrepareKey(string path)
+        {
+            return _prefix + path.Replace("\\", Separator);
+        }
+
+        public async Task<Stream> GetAsync(string path, CancellationToken cancellationToken = default)
+        {
+            var stream = new MemoryStream();
+
+            try
+            {
+                await _client.GetObjectAsync(_bucket, PrepareKey(path), s => s.CopyTo(stream),
+                    cancellationToken: cancellationToken);
+
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+            catch (Exception)
+            {
+                stream.Dispose();
+
+                // TODO
+                throw;
+            }
+
+            return stream;
+        }
+
+        public Task<Uri> GetDownloadUriAsync(string path, CancellationToken cancellationToken = default)
+        {
+            var url = _client.PresignedGetObjectAsync(_bucket, PrepareKey(path), 60 * 60);
+            return url.ContinueWith(t => new Uri(t.Result), cancellationToken);
+        }
+
+        public async Task<StoragePutResult> PutAsync(string path, Stream content, string contentType, CancellationToken cancellationToken = default)
+        {
+            // TODO: Uploads should be idempotent. This should fail if and only if the blob
+            // already exists but has different content.
+            var objName = PrepareKey(path);
+
+            await _client.PutObjectAsync(_bucket, objName, content, content.Length,
+                cancellationToken: cancellationToken);
+
+            return StoragePutResult.Success;
+        }
+
+        public async Task DeleteAsync(string path, CancellationToken cancellationToken = default)
+        {
+            await _client.RemoveObjectAsync(_bucket, PrepareKey(path), cancellationToken);
+        }
+    }
+}

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\BaGet.Database.SqlServer\BaGet.Database.SqlServer.csproj" />
     <ProjectReference Include="..\BaGet.Gcp\BaGet.Gcp.csproj" />
     <ProjectReference Include="..\BaGet.Hosting\BaGet.Hosting.csproj" />
+    <ProjectReference Include="..\BaGet.Minio\BaGet.Minio.csproj" />
     <ProjectReference Include="..\BaGet.Protocol\BaGet.Protocol.csproj" />
   </ItemGroup>
 

--- a/src/BaGet/ConfigureBaGetOptions.cs
+++ b/src/BaGet/ConfigureBaGetOptions.cs
@@ -38,6 +38,7 @@ namespace BaGet
             {
                 "AliyunOss",
                 "AwsS3",
+                "Minio",
                 "AzureBlobStorage",
                 "Filesystem",
                 "GoogleCloud",

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using BaGet.Core;
 using BaGet.Hosting;
+using BaGet.Minio;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
@@ -74,6 +75,7 @@ namespace BaGet
             app.AddFileStorage();
             app.AddAliyunOssStorage();
             app.AddAwsS3Storage();
+            app.AddMinioStorage();
             app.AddAzureBlobStorage();
             app.AddGoogleCloudStorage();
 


### PR DESCRIPTION
This PR adds a `IStorageService` to BaGet that uses Minio, an open-source S3 compatible storage provider popular for self-hosted and internal object storage.  Furthermore the [.NET Minio Client Library](https://github.com/minio/minio-dotnet) used in this PR supports any S3 compatible provider and so can also be used directly for AWS as well as Minio.

This addresses #621, #551, and #271 (which resulted in PR #272 but never got merged).

I copied the layout of the AWS provider, making changes only for the specific Minio client libraries and configuration options.

