### PR TITLE
Accept more symbol download URL patterns

### DIFF
--- a/src/BaGet.Core/Storage/SymbolStorageService.cs
+++ b/src/BaGet.Core/Storage/SymbolStorageService.cs
@@ -62,8 +62,12 @@ namespace BaGet.Core
             {
                 throw new ArgumentException(nameof(key));
             }
-            
-            key = key.Substring(0,32) + "ffffffff";
+
+            // The key's first 32 characters are the GUID, the remaining characters are the age.
+            // See: https://github.com/dotnet/symstore/blob/98717c63ec8342acf8a07aa5c909b88bd0c664cc/docs/specs/SSQP_Key_Conventions.md#portable-pdb-signature
+            // Debuggers should always use the age "ffffffff", however Visual Studio 2019
+            // users have reported other age values. We will ignore the age.
+            key = key.Substring(0, 32) + "ffffffff";
 
             return Path.Combine(
                 SymbolsPathPrefix,

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -374,14 +374,16 @@ namespace BaGet.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact]
-        public async Task PrefixedSymbolDownloadReturnsOk()
+        [Theory]
+        [InlineData("api/download/symbols/testdata.pdb/16F71ED8DD574AA2AD4A22D29E9C981B1/testdata.pdb")]
+        [InlineData("api/download/symbols/testdata.pdb/16F71ED8DD574AA2AD4A22D29E9C981B/testdata.pdb")]
+        [InlineData("api/download/symbols/testprefix/testdata.pdb/16F71ED8DD574AA2AD4A22D29E9C981Bffffffff/testdata.pdb")]
+        public async Task MalformedSymbolDownloadReturnsOk(string uri)
         {
             await _factory.AddPackageAsync(_packageStream);
             await _factory.AddSymbolPackageAsync(_symbolPackageStream);
 
-            using var response = await _client.GetAsync(
-                "api/download/symbols/testprefix/testdata.pdb/16F71ED8DD574AA2AD4A22D29E9C981Bffffffff/testdata.pdb");
+            using var response = await _client.GetAsync(uri);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }


### PR DESCRIPTION
This is @ahehl's pull request https://github.com/loic-sharma/BaGet/pull/626 with some tweaks:

> The symbol files are currently stored in directories with the name {key}ffffffff
> In order to support incoming symbol requests with the patterns
> 
> {key}ffffffff
> {key}1
> {key}
> 
> the keys have to be mapped to the already existing directory structure

Addresses https://github.com/loic-sharma/BaGet/issues/224