### PR TITLE
Add support for MiniO storage backend

### DIFF
--- a/docs/installation/aws.md
+++ b/docs/installation/aws.md
@@ -22,12 +22,17 @@ Update the `appsettings.json` file:
         "Region": "us-west-1",
         "Bucket": "foo",
         "AccessKey": "",
-        "SecretKey": ""
+        "SecretKey": "",
+        "ServiceUrl": "",
+        "UseHttp": false,
+        "ForcePathStyle": false
     },
 
     ...
 }
 ```
+
+To support MiniO as S3 compatible storage backend provide MiniO installation url in `ServiceUrl`, set `ForcePathStyle` to true.
 
 ### Amazon RDS
 

--- a/docs/installation/aws.md
+++ b/docs/installation/aws.md
@@ -32,7 +32,25 @@ Update the `appsettings.json` file:
 }
 ```
 
-To support MiniO as S3 compatible storage backend provide MiniO installation url in `ServiceUrl`, set `ForcePathStyle` to true.
+To use MinIO as an S3 compatible storage backend, provide the MinIO installation URL in `ServiceUrl` and set `ForcePathStyle` to `true`:
+
+```json
+{
+    ...
+
+    "Storage": {
+        "Type": "AwsS3",
+        "Region": "us-west-1",
+        "Bucket": "foo",
+        "AccessKey": "",
+        "SecretKey": "",
+        "ServiceUrl": "",
+        "ForcePathStyle": false,
+        "UseHttp": false
+    },
+
+    ...
+}
 
 ### Amazon RDS
 

--- a/src/BaGet.Aws/AwsApplicationExtensions.cs
+++ b/src/BaGet.Aws/AwsApplicationExtensions.cs
@@ -31,10 +31,23 @@ namespace BaGet
             {
                 var options = provider.GetRequiredService<IOptions<S3StorageOptions>>().Value;
 
+                if (options.ForcePathStyle)
+                {
+                    // Required to support presigned urls generation for MiniO configured to us-east-1 region
+                    AWSConfigsS3.UseSignatureVersion4 = true; 
+                }
+
                 var config = new AmazonS3Config
                 {
-                    RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region)
+                    RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region),
+                    ForcePathStyle = options.ForcePathStyle,
+                    UseHttp = options.UseHttp
                 };
+
+                if (!string.IsNullOrWhiteSpace(options.ServiceUrl))
+                {
+                    config.ServiceURL = options.ServiceUrl;
+                }
 
                 if (options.UseInstanceProfile)
                 {

--- a/src/BaGet.Aws/S3StorageOptions.cs
+++ b/src/BaGet.Aws/S3StorageOptions.cs
@@ -22,5 +22,11 @@ namespace BaGet.Aws
         public bool UseInstanceProfile { get; set; }
 
         public string AssumeRoleArn { get; set; }
+
+        public bool ForcePathStyle { get; set; } = false;
+
+        public string ServiceUrl { get; set; }
+
+        public bool UseHttp { get; set; }
     }
 }

--- a/src/BaGet.Aws/S3StorageOptions.cs
+++ b/src/BaGet.Aws/S3StorageOptions.cs
@@ -23,7 +23,7 @@ namespace BaGet.Aws
 
         public string AssumeRoleArn { get; set; }
 
-        public bool ForcePathStyle { get; set; } = false;
+        public bool ForcePathStyle { get; set; }
 
         public string ServiceUrl { get; set; }
 


### PR DESCRIPTION
This PR is yet another attempt to address  #621, #551, and #271

Added additional settings to `S3StorageOptions`:
- `ForcePathStyle = false` setting to true will make AWSSDK.net compatible with MiniO installations
- `ServiceUrl` - ability to override S3 service location
- `UseHttp` - ability to use HTTP protocol for `ServiceUrl`

All those settings are real settings from actual `AmazonS3Config` from official AWSSDK library

There is already another PR's to address those issues: https://github.com/loic-sharma/BaGet/pull/644 and https://github.com/loic-sharma/BaGet/pull/272

My PR is much less intrusive, only adding ability to pass settings that are already exists in AwsSdk library