### PR TITLE
Support embedded READMEs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -40,7 +40,7 @@
     <MicrosoftAspNetCorePackageVersion>3.1.1</MicrosoftAspNetCorePackageVersion>
     <MicrosoftEntityFrameworkCorePackageVersion>3.1.1</MicrosoftEntityFrameworkCorePackageVersion>
     <MicrosoftExtensionsPackageVersion>3.1.1</MicrosoftExtensionsPackageVersion>
-    <NuGetPackageVersion>5.4.0</NuGetPackageVersion>
+    <NuGetPackageVersion>5.10.0</NuGetPackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == ''">

--- a/tests/BaGet.Tests/ApiIntegrationTests.cs
+++ b/tests/BaGet.Tests/ApiIntegrationTests.cs
@@ -274,7 +274,7 @@ namespace BaGet.Tests
             ""authors"": ""Test author"",
             ""dependencyGroups"": [
               {
-                ""targetFramework"": ""net50"",
+                ""targetFramework"": ""net5.0"",
                 ""dependencies"": []
               }
             ],

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <MicrosoftAspNetCorePackageVersion>3.1.1</MicrosoftAspNetCorePackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
-    <NuGetPackageVersion>5.4.0</NuGetPackageVersion>
+    <NuGetPackageVersion>5.10.0</NuGetPackageVersion>
     <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
NuGet's official embedded READMEs declares the README using the [`readme`](https://docs.microsoft.com/en-us/nuget/reference/nuspec#readme) metadata in the package's .nuspec.