### PR TITLE
fix: use new dotnet images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /src
 COPY /src .
 RUN dotnet restore BaGet


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * dotnet image names have changed

https://hub.docker.com/_/microsoft-dotnet-aspnet
https://hub.docker.com/_/microsoft-dotnet-sdk