### PR TITLE
Enable GitHub Codespace development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT=3.1
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+{
+	"name": "C# (.NET)",
+	"runArgs": ["--init"],
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "3.1",
+			// Options
+			"NODE_VERSION": "lts/*",
+			"INSTALL_AZURE_CLI": "false"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+
+	// [Optional] To reuse of your local HTTPS dev cert:
+	//
+	// 1. Export it locally using this command:
+	//    * Windows PowerShell:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	//    * macOS/Linux terminal:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	//
+	// 2. Uncomment these 'remoteEnv' lines:
+	//    "remoteEnv": {
+	// 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+	//        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+	//    },
+	//
+	// 3. Do one of the following depending on your scenario:
+	//    * When using GitHub Codespaces and/or Remote - Containers:
+	//      1. Start the container
+	//      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+	//      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+	//
+	//    * If only using Remote - Containers with a local container, uncomment this line instead:
+	//      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/scripts/container-creation.sh
+++ b/.devcontainer/scripts/container-creation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# See: https://github.com/dotnet/aspnetcore/blob/4b4265972d1155e415633a4a177f159b940cf3bb/.devcontainer/scripts/container-creation.sh
+
+set -e
+
+# Install SDK and tool dependencies before container starts
+# Also run the full restore on the repo so that go-to definition
+# and other language features will be available in C# files
+dotnet restore
+
+# Add .NET Dev Certs to environment to facilitate debugging.
+# Do **NOT** do this in a public base image as all images inheriting
+# from the base image would inherit these dev certs as well.
+dotnet dev-certs https
+
+# The container creation script is executed in a new Bash instance
+# so we exit at the end to avoid the creation process lingering.
+exit

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/BaGet/bin/Debug/netcoreapp2.2/BaGet.dll",
+            "program": "${workspaceFolder}/src/BaGet/bin/Debug/netcoreapp3.1/BaGet.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/BaGet",
             "stopAtEntry": false,


### PR DESCRIPTION
Enables basic GitHub Codespace support by adding a dev container image.

## ⚠ Known problems:

### Broken links
The [Forwarded Headers Middleware](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-5.0#forwarded-headers) does not seem to be working as expected. For example:

https://github.com/loic-sharma/BaGet/blob/8474f25a0e4822a22f55b58f9e17532c1e0d1179/src/BaGet.Web/BaGetUrlGenerator.cs#L105-L119

The `_httpContextAccessor` incorrectly has the `https://localhost` host at this point. This needs more investigation as `IUrlHelper` links appear to be working as expected.

### Upload failures

Upload fails with `error: Response status code does not indicate success: 413 (Request Entity Too Large).`. I was able to work around this by enabling upstreaming to nuget.org and download artifacts.