### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/dotnet/.devcontainer/base.Dockerfile
 
-# [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT=3.1
+# [Choice] .NET version: 6.0, 5.0, 3.1, 2.1
+ARG VARIANT=6.0
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
     - name: Test
       run: dotnet test --verbosity normal
 
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
     - name: Publish
       run: dotnet publish src/BaGet --configuration Release --output artifacts
     - name: Upload
@@ -59,7 +59,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
     - name: Pack
       run: dotnet pack --configuration Release --output artifacts
     - name: Push

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mmcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY /src .
 RUN dotnet restore BaGet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+FROM mmcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY /src .
 RUN dotnet restore BaGet

--- a/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
+++ b/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>IDE0007</NoWarn>
   </PropertyGroup>

--- a/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
+++ b/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
+++ b/samples/BaGet.Protocol.Samples.Tests/BaGet.Protocol.Samples.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/samples/BaGetWebApplication/BaGetWebApplication.csproj
+++ b/samples/BaGetWebApplication/BaGetWebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aliyun/BaGet.Aliyun.csproj
+++ b/src/BaGet.Aliyun/BaGet.Aliyun.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageTags>NuGet;Alibaba;Cloud</PackageTags>
     <Description>The libraries to host BaGet on Alibaba Cloud (Aliyun).</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aliyun/BaGet.Aliyun.csproj
+++ b/src/BaGet.Aliyun/BaGet.Aliyun.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.9.1" />
+    <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.110.20" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.27" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.105" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet;Amazon;Cloud</PackageTags>
     <Description>The libraries to host BaGet on AWS.</Description>
   </PropertyGroup>

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.105" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aws/BaGet.Aws.csproj
+++ b/src/BaGet.Aws/BaGet.Aws.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.105" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.22" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.115" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
-    <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Search" Version="5.0.1" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Azure/BaGet.Azure.csproj
+++ b/src/BaGet.Azure/BaGet.Azure.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet;Azure;Cloud</PackageTags>
     <Description>The libraries to host BaGet on Azure.</Description>
   </PropertyGroup>

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet</PackageTags>
     <Description>The core libraries that power BaGet.</Description>
   </PropertyGroup>

--- a/src/BaGet.Core/BaGet.Core.csproj
+++ b/src/BaGet.Core/BaGet.Core.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
+++ b/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
+++ b/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
+++ b/src/BaGet.Database.MySql/BaGet.Database.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGet on MySQL.</Description>

--- a/src/BaGet.Database.MySql/Migrations/20181212113156_Initial.cs
+++ b/src/BaGet.Database.MySql/Migrations/20181212113156_Initial.cs
@@ -8,32 +8,50 @@ namespace BaGet.Database.MySql.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.AlterDatabase()
+                .Annotation("MySql:CharSet", "utf8mb4");
+
             migrationBuilder.CreateTable(
                 name: "Packages",
                 columns: table => new
                 {
-                    Key = table.Column<int>(nullable: false)
+                    Key = table.Column<int>(type: "int", nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    Id = table.Column<string>(maxLength: 128, nullable: false),
-                    Authors = table.Column<string>(maxLength: 4000, nullable: true),
-                    Description = table.Column<string>(maxLength: 4000, nullable: true),
-                    Downloads = table.Column<long>(nullable: false),
-                    HasReadme = table.Column<bool>(nullable: false),
-                    Language = table.Column<string>(maxLength: 20, nullable: true),
-                    Listed = table.Column<bool>(nullable: false),
-                    MinClientVersion = table.Column<string>(maxLength: 44, nullable: true),
-                    Published = table.Column<DateTime>(nullable: false),
-                    RequireLicenseAcceptance = table.Column<bool>(nullable: false),
-                    Summary = table.Column<string>(maxLength: 4000, nullable: true),
-                    Title = table.Column<string>(maxLength: 256, nullable: true),
-                    IconUrl = table.Column<string>(maxLength: 4000, nullable: true),
-                    LicenseUrl = table.Column<string>(maxLength: 4000, nullable: true),
-                    ProjectUrl = table.Column<string>(maxLength: 4000, nullable: true),
-                    RepositoryUrl = table.Column<string>(maxLength: 4000, nullable: true),
-                    RepositoryType = table.Column<string>(maxLength: 100, nullable: true),
-                    Tags = table.Column<string>(maxLength: 4000, nullable: true),
-                    RowVersion = table.Column<DateTime>(rowVersion: true, nullable: true),
-                    Version = table.Column<string>(maxLength: 64, nullable: false)
+                    Id = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Authors = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Downloads = table.Column<long>(type: "bigint", nullable: false),
+                    HasReadme = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    Language = table.Column<string>(type: "varchar(20)", maxLength: 20, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Listed = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    MinClientVersion = table.Column<string>(type: "varchar(44)", maxLength: 44, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Published = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    RequireLicenseAcceptance = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    Summary = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Title = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    IconUrl = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    LicenseUrl = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ProjectUrl = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    RepositoryUrl = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    RepositoryType = table.Column<string>(type: "varchar(100)", maxLength: 100, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Tags = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    RowVersion = table.Column<DateTime>(type: "timestamp(6)", rowVersion: true, nullable: true)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn),
+                    Version = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
                 },
                 constraints: table =>
                 {
@@ -44,12 +62,15 @@ namespace BaGet.Database.MySql.Migrations
                 name: "PackageDependencies",
                 columns: table => new
                 {
-                    Key = table.Column<int>(nullable: false)
+                    Key = table.Column<int>(type: "int", nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    Id = table.Column<string>(maxLength: 128, nullable: true),
-                    VersionRange = table.Column<string>(maxLength: 256, nullable: true),
-                    TargetFramework = table.Column<string>(maxLength: 256, nullable: true),
-                    PackageKey = table.Column<int>(nullable: false)
+                    Id = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    VersionRange = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    TargetFramework = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    PackageKey = table.Column<int>(type: "int", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/BaGet.Database.MySql/Migrations/20190303071640_AddSearchDimensions.cs
+++ b/src/BaGet.Database.MySql/Migrations/20190303071640_AddSearchDimensions.cs
@@ -12,23 +12,17 @@ namespace BaGet.Database.MySql.Migrations
                 name: "FK_PackageDependencies_Packages_PackageKey",
                 table: "PackageDependencies");
 
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                rowVersion: true,
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldNullable: true);
-
             migrationBuilder.AddColumn<bool>(
                 name: "IsPrerelease",
                 table: "Packages",
+                type: "tinyint(1)",
                 nullable: false,
                 defaultValue: false);
 
             migrationBuilder.AddColumn<int>(
                 name: "SemVerLevel",
                 table: "Packages",
+                type: "int",
                 nullable: false,
                 defaultValue: 0);
 
@@ -42,11 +36,13 @@ namespace BaGet.Database.MySql.Migrations
                 name: "PackageTypes",
                 columns: table => new
                 {
-                    Key = table.Column<int>(nullable: false)
+                    Key = table.Column<int>(type: "int", nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    Name = table.Column<string>(maxLength: 512, nullable: true),
-                    Version = table.Column<string>(maxLength: 64, nullable: true),
-                    PackageKey = table.Column<int>(nullable: false)
+                    Name = table.Column<string>(type: "varchar(255)", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Version = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    PackageKey = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -63,10 +59,11 @@ namespace BaGet.Database.MySql.Migrations
                 name: "TargetFrameworks",
                 columns: table => new
                 {
-                    Key = table.Column<int>(nullable: false)
+                    Key = table.Column<int>(type: "int", nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    Moniker = table.Column<string>(maxLength: 256, nullable: true),
-                    PackageKey = table.Column<int>(nullable: false)
+                    Moniker = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    PackageKey = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -136,14 +133,6 @@ namespace BaGet.Database.MySql.Migrations
             migrationBuilder.DropColumn(
                 name: "SemVerLevel",
                 table: "Packages");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldRowVersion: true,
-                oldNullable: true);
 
             migrationBuilder.AlterColumn<int>(
                 name: "PackageKey",

--- a/src/BaGet.Database.MySql/Migrations/20190914215810_AddOriginalVersionStringColumn.cs
+++ b/src/BaGet.Database.MySql/Migrations/20190914215810_AddOriginalVersionStringColumn.cs
@@ -7,17 +7,10 @@ namespace BaGet.Database.MySql.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                rowVersion: true,
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldNullable: true);
-
             migrationBuilder.AddColumn<string>(
                 name: "OriginalVersion",
                 table: "Packages",
+                type: "varchar(64)",
                 maxLength: 64,
                 nullable: true);
         }
@@ -27,14 +20,6 @@ namespace BaGet.Database.MySql.Migrations
             migrationBuilder.DropColumn(
                 name: "OriginalVersion",
                 table: "Packages");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldRowVersion: true,
-                oldNullable: true);
         }
     }
 }

--- a/src/BaGet.Database.MySql/Migrations/20200109085155_AddReleaseNotesStringColumn.cs
+++ b/src/BaGet.Database.MySql/Migrations/20200109085155_AddReleaseNotesStringColumn.cs
@@ -7,17 +7,10 @@ namespace BaGet.Database.MySql.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                rowVersion: true,
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldNullable: true);
-
             migrationBuilder.AddColumn<string>(
                 name: "ReleaseNotes",
                 table: "Packages",
+                type: "longtext",
                 maxLength: 4000,
                 nullable: true);
         }
@@ -27,14 +20,6 @@ namespace BaGet.Database.MySql.Migrations
             migrationBuilder.DropColumn(
                 name: "ReleaseNotes",
                 table: "Packages");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldRowVersion: true,
-                oldNullable: true);
         }
     }
 }

--- a/src/BaGet.Database.MySql/Migrations/20200210004047_AddHasEmbeddedIconColumn.cs
+++ b/src/BaGet.Database.MySql/Migrations/20200210004047_AddHasEmbeddedIconColumn.cs
@@ -8,18 +8,10 @@ namespace BaGet.Database.MySql.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                rowVersion: true,
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldNullable: true)
-                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
-
             migrationBuilder.AddColumn<bool>(
                 name: "HasEmbeddedIcon",
                 table: "Packages",
+                type: "tinyint(1)",
                 nullable: false,
                 defaultValue: false);
         }
@@ -29,15 +21,6 @@ namespace BaGet.Database.MySql.Migrations
             migrationBuilder.DropColumn(
                 name: "HasEmbeddedIcon",
                 table: "Packages");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldRowVersion: true,
-                oldNullable: true)
-                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
         }
     }
 }

--- a/src/BaGet.Database.MySql/Migrations/20210919191554_RemoveReleaseNotesMaxLength.cs
+++ b/src/BaGet.Database.MySql/Migrations/20210919191554_RemoveReleaseNotesMaxLength.cs
@@ -4,32 +4,15 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace BaGet.Database.MySql.Migrations
 {
+    // This was a migration without any sense, but I keep it cause of existing data
     public partial class RemoveReleaseNotesMaxLength : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                rowVersion: true,
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldType: "timestamp(6)",
-                oldNullable: true)
-                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "RowVersion",
-                table: "Packages",
-                type: "timestamp(6)",
-                nullable: true,
-                oldClrType: typeof(DateTime),
-                oldRowVersion: true,
-                oldNullable: true)
-                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
         }
     }
 }

--- a/src/BaGet.Database.MySql/Migrations/20220123000903_AdjustTypesAccordingToLastProviderVersion.Designer.cs
+++ b/src/BaGet.Database.MySql/Migrations/20220123000903_AdjustTypesAccordingToLastProviderVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BaGet.Database.MySql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BaGet.Database.MySql.Migrations
 {
     [DbContext(typeof(MySqlContext))]
-    partial class MySqlContextModelSnapshot : ModelSnapshot
+    [Migration("20220123000903_AdjustTypesAccordingToLastProviderVersion")]
+    partial class AdjustTypesAccordingToLastProviderVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BaGet.Database.MySql/Migrations/20220123000903_AdjustTypesAccordingToLastProviderVersion.cs
+++ b/src/BaGet.Database.MySql/Migrations/20220123000903_AdjustTypesAccordingToLastProviderVersion.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BaGet.Database.MySql.Migrations
+{
+    public partial class AdjustTypesAccordingToLastProviderVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PackageTypes",
+                type: "varchar(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(512)",
+                oldMaxLength: 512,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tags",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Summary",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RowVersion",
+                table: "Packages",
+                type: "timestamp(6)",
+                rowVersion: true,
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp(6)",
+                oldRowVersion: true,
+                oldNullable: true)
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RepositoryUrl",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProjectUrl",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseUrl",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IconUrl",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Authors",
+                table: "Packages",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4",
+                oldMaxLength: 4000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PackageTypes",
+                type: "varchar(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tags",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Summary",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RowVersion",
+                table: "Packages",
+                type: "timestamp(6)",
+                rowVersion: true,
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp(6)",
+                oldRowVersion: true,
+                oldNullable: true)
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RepositoryUrl",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReleaseNotes",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProjectUrl",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseUrl",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IconUrl",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Authors",
+                table: "Packages",
+                type: "longtext CHARACTER SET utf8mb4",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/BaGet.Database.MySql/MySqlApplicationExtensions.cs
+++ b/src/BaGet.Database.MySql/MySqlApplicationExtensions.cs
@@ -15,7 +15,7 @@ namespace BaGet
             {
                 var databaseOptions = provider.GetRequiredService<IOptionsSnapshot<DatabaseOptions>>();
 
-                options.UseMySql(databaseOptions.Value.ConnectionString);
+                options.UseMySql(databaseOptions.Value.ConnectionString, ServerVersion.AutoDetect(databaseOptions.Value.ConnectionString));
             });
 
             return app;

--- a/src/BaGet.Database.MySql/MySqlContext.cs
+++ b/src/BaGet.Database.MySql/MySqlContext.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using BaGet.Core;
 using Microsoft.EntityFrameworkCore;
 using MySqlConnector;
@@ -7,17 +9,19 @@ namespace BaGet.Database.MySql
     public class MySqlContext : AbstractContext<MySqlContext>
     {
         /// <summary>
+        /// Max string length for mapping to varchar(N)
+        /// It string length will be greater than that value, it would be mapped to a longtext
+        /// </summary>
+        private const int MaxAllowedVarcharLength = 256;
+
+        /// <summary>
         /// The MySQL Server error code for when a unique constraint is violated.
         /// </summary>
         private const int UniqueConstraintViolationErrorCode = 1062;
 
-        public MySqlContext(DbContextOptions<MySqlContext> options) : base(options)
+        public MySqlContext(DbContextOptions<MySqlContext> options)
+            : base(options)
         {
-        }
-
-        public override bool IsUniqueConstraintViolationException(DbUpdateException exception)
-        {
-            return exception.InnerException is MySqlException {Number: UniqueConstraintViolationErrorCode};
         }
 
         /// <summary>
@@ -25,5 +29,31 @@ namespace BaGet.Database.MySql
         /// See: https://dev.mysql.com/doc/refman/8.0/en/subquery-restrictions.html
         /// </summary>
         public override bool SupportsLimitInSubqueries => false;
+
+        public override bool IsUniqueConstraintViolationException(DbUpdateException exception) =>
+            exception.InnerException is MySqlException { Number: UniqueConstraintViolationErrorCode };
+
+        /// <summary>
+        /// MySQL has a limit of row size - 65535 bytes
+        /// So we map strings, strings array & uris, which are longer than 256 symbols to longtext MySQL type
+        /// See: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1606
+        /// </summary>
+        /// <param name="builder">EF Core model builder</param>
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+
+            var longtextProperties = builder.Model
+                .GetEntityTypes()
+                .SelectMany(e => e.GetProperties())
+                .Where(e =>
+                    (e.ClrType == typeof(string) || e.ClrType == typeof(string[]) || e.ClrType == typeof(Uri)) &&
+                    e.GetMaxLength() > MaxAllowedVarcharLength);
+
+            foreach (var property in longtextProperties)
+            {
+                property.SetMaxLength(null);
+            }
+        }
     }
 }

--- a/src/BaGet.Database.MySql/MySqlContext.cs
+++ b/src/BaGet.Database.MySql/MySqlContext.cs
@@ -35,7 +35,7 @@ namespace BaGet.Database.MySql
 
         /// <summary>
         /// MySQL has a limit of row size - 65535 bytes
-        /// So we map strings, strings array & uris, which are longer than 256 symbols to longtext MySQL type
+        /// So we map string, string[] and URI, which are longer than 256 symbols to longtext MySQL type
         /// See: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1606
         /// </summary>
         /// <param name="builder">EF Core model builder</param>

--- a/src/BaGet.Database.MySql/MySqlContext.cs
+++ b/src/BaGet.Database.MySql/MySqlContext.cs
@@ -1,6 +1,6 @@
 using BaGet.Core;
 using Microsoft.EntityFrameworkCore;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace BaGet.Database.MySql
 {
@@ -17,8 +17,7 @@ namespace BaGet.Database.MySql
 
         public override bool IsUniqueConstraintViolationException(DbUpdateException exception)
         {
-            return exception.InnerException is MySqlException mysqlException &&
-                   mysqlException.Number == UniqueConstraintViolationErrorCode;
+            return exception.InnerException is MySqlException {Number: UniqueConstraintViolationErrorCode};
         }
 
         /// <summary>

--- a/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
+++ b/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
+++ b/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGet on PostgreSQL.</Description>

--- a/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
+++ b/src/BaGet.Database.PostgreSql/BaGet.Database.PostgreSql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.1.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
+++ b/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGet on SQL Server.</Description>

--- a/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
+++ b/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
+++ b/src/BaGet.Database.SqlServer/BaGet.Database.SqlServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
+++ b/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
+++ b/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGet on SQLite.</Description>

--- a/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
+++ b/src/BaGet.Database.Sqlite/BaGet.Database.Sqlite.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Gcp/BaGet.Gcp.csproj
+++ b/src/BaGet.Gcp/BaGet.Gcp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Gcp/BaGet.Gcp.csproj
+++ b/src/BaGet.Gcp/BaGet.Gcp.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet;Google;Cloud</PackageTags>
     <Description>The libraries to host BaGet on the Google Cloud Platform.</Description>
   </PropertyGroup>

--- a/src/BaGet.Gcp/BaGet.Gcp.csproj
+++ b/src/BaGet.Gcp/BaGet.Gcp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.6.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.0.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet;Protocol</PackageTags>
     <Description>Libraries to interact with NuGet server APIs.</Description>
   </PropertyGroup>

--- a/src/BaGet.Protocol/BaGet.Protocol.csproj
+++ b/src/BaGet.Protocol/BaGet.Protocol.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.0.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/BaGet.Web/BaGet.Web.csproj
+++ b/src/BaGet.Web/BaGet.Web.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer" Version="2.13.14" />
-    <PackageReference Include="Markdig" Version="0.26.0" />
+    <PackageReference Include="Humanizer" Version="2.14.1" />
+    <PackageReference Include="Markdig" Version="0.27.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet.Web/BaGet.Web.csproj
+++ b/src/BaGet.Web/BaGet.Web.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <PackageTags>NuGet</PackageTags>
     <Description>BaGet's NuGet server implementation</Description>
     <RootNamespace>BaGet.Web</RootNamespace>

--- a/src/BaGet.Web/BaGet.Web.csproj
+++ b/src/BaGet.Web/BaGet.Web.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer" Version="2.11.10" />
+    <PackageReference Include="Humanizer" Version="2.13.14" />
     <PackageReference Include="Markdig" Version="0.26.0" />
   </ItemGroup>
 

--- a/src/BaGet.Web/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGet.Web/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 using BaGet.Core;
 using BaGet.Web;
 using Microsoft.AspNetCore.Mvc;
@@ -16,10 +17,9 @@ namespace BaGet
                 .AddRouting(options => options.LowercaseUrls = true)
                 .AddControllers()
                 .AddApplicationPart(typeof(PackageContentController).Assembly)
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddJsonOptions(options =>
                 {
-                    options.JsonSerializerOptions.IgnoreNullValues = true;
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
                 });
 
             services.AddRazorPages();

--- a/src/BaGet.Web/Pages/Index.cshtml
+++ b/src/BaGet.Web/Pages/Index.cshtml
@@ -188,7 +188,7 @@ else
 
         { "divider1", "-" },
         { "header1", ".NET" },
-
+        { "net6.0", ".NET 6.0" },
         { "net5.0", ".NET 5.0" },
 
         { "divider2", "-" },

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCorePackageVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(MicrosoftAspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCorePackageVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -5,9 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(MicrosoftAspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,12 +31,20 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <!-- NuGet dependencies shared across projects -->
+  <PropertyGroup>
+    <MicrosoftAspNetCorePackageVersion>6.0.1</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>6.0.1</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
+    <NuGetPackageVersion>6.1.0</NuGetPackageVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == ''">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,16 +35,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <!-- NuGet dependencies shared across projects -->
-  <PropertyGroup>
-    <MicrosoftAspNetCorePackageVersion>3.1.18</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftEntityFrameworkCorePackageVersion>3.1.18</MicrosoftEntityFrameworkCorePackageVersion>
-    <MicrosoftExtensionsPackageVersion>3.1.18</MicrosoftExtensionsPackageVersion>
-    <NuGetPackageVersion>5.10.0</NuGetPackageVersion>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == ''">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   <!-- Compiler properties -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>10</LangVersion>
 
     <!-- Don't warn if there are missing XMl comment for publicly visible type or member-->
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -8,11 +8,4 @@
     <ProjectReference Include="..\..\src\BaGet.Core\BaGet.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -8,4 +8,11 @@
     <ProjectReference Include="..\..\src\BaGet.Core\BaGet.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
+++ b/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -20,7 +21,6 @@ namespace BaGet.Core.Tests.Metadata
         {
             // Arrange
             var packageId = "BaGet.Test";
-            var authors = new string[] { "test" };
 
             var packages = new List<Package>
             {
@@ -52,14 +52,15 @@ namespace BaGet.Core.Tests.Metadata
         /// Create a fake <see cref="Package"></see> with the minimum metadata needed by the <see cref="RegistrationBuilder"></see>.
         /// </summary>
         private Package GetTestPackage(string packageId, string version)
-        {            
+        {
             return new Package
             {
                 Id = packageId,
-                Authors = new string[] { "test" },
-                PackageTypes = new List<PackageType> { new PackageType { Name = "test" } },
-                Dependencies = new List<PackageDependency> { },
+                Authors = new[] { "test" },
+                PackageTypes = new List<PackageType> { new() { Name = "test" } },
+                Dependencies = new List<PackageDependency>(),
                 Version = new NuGetVersion(version),
+                Published = new DateTime(2022, 01, 01)
             };
         }
     }

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -23,11 +23,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -23,4 +23,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Update="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -12,10 +12,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCorePackageVersion)" />
-    <PackageReference Update="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
+++ b/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
+++ b/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
@@ -8,11 +8,4 @@
     <ProjectReference Include="..\..\src\BaGet.Web\BaGet.Web.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
+++ b/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
@@ -8,4 +8,11 @@
     <ProjectReference Include="..\..\src\BaGet.Web\BaGet.Web.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,6 +10,13 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
+  <!-- NuGet dependencies shared across projects -->
+  <PropertyGroup>
+    <MicrosoftAspNetCorePackageVersion>6.0.1</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
+    <NuGetPackageVersion>6.1.0</NuGetPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,23 +10,15 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <!-- NuGet dependencies shared across projects -->
-  <PropertyGroup>
-    <MicrosoftAspNetCorePackageVersion>3.1.18</MicrosoftAspNetCorePackageVersion>
-    <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
-    <NuGetPackageVersion>5.10.0</NuGetPackageVersion>
-    <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi @loic-sharma,

Thank you for awesome project (hope it is alive). Wanna contribute and make some new feature extensions, but first of all, the code base of BaGet should be updated to the new stack. So I have decided to start from update PR.
_____
This closes #707 and #618 (as outdated). Also it helps us to use the latest features/libraries and performance of .NET 6
_____
Next work should be done:
- [X] Update projects to .NET 6 and C# 10
- [X] Update Dockerfile
- [X] Update pipelines
- [X] Bump package dependencies
- [x] Check/adjust tests, if needed
- [x] Add .NET 6 to list of supported frameworks

Test:
- [x] Docker
- [x] MySQL
- [x] Postgres
- [x] SQLite
- [x] SQL Server

Also need to pay attention to:
- [x] `Pomelo.EntityFrameworkCore.MySql v6.0.0` has breaking changes, now MySql version should be specified. Now the feature of version autodetection was used in `BaGet.Database.MySql`
- [x] ~~`BaGet.Azure` uses very outdated libraries `Microsoft.Azure.Search` & `Microsoft.Azure.Storage.Blob`. Last release `Azure.Search.Documents`  & ` Azure.Storage.Blobs` should be used and project should be rewritten to their API (I think we will extract it to the new issue, but I need to document this founding here)~~ (extracted to #720)
_____
I will continue to test/adjust the project, but help would be appreciated. I think when majority of items would be done, it would be cool to release a new alpha version for mass testing 

