### PR TITLE
feat: use option pattern to configure azure table name

### DIFF
--- a/src/BaGet.Azure/Configuration/AzureTableOptions.cs
+++ b/src/BaGet.Azure/Configuration/AzureTableOptions.cs
@@ -6,5 +6,7 @@ namespace BaGet.Azure
     {
         [Required]
         public string ConnectionString { get; set; }
+
+        [Required] public string TableName { get; set; } = "Packages";
     }
 }

--- a/src/BaGet.Azure/Table/TablePackageDatabase.cs
+++ b/src/BaGet.Azure/Table/TablePackageDatabase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BaGet.Core;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
 namespace BaGet.Azure
@@ -15,9 +16,9 @@ namespace BaGet.Azure
     /// </summary>
     public class TablePackageDatabase : IPackageDatabase
     {
-        private const string TableName = "Packages";
         private const int MaxPreconditionFailures = 5;
 
+        private readonly string _tableName;
         private readonly TableOperationBuilder _operationBuilder;
         private readonly CloudTable _table;
         private readonly ILogger<TablePackageDatabase> _logger;
@@ -25,10 +26,12 @@ namespace BaGet.Azure
         public TablePackageDatabase(
             TableOperationBuilder operationBuilder,
             CloudTableClient client,
-            ILogger<TablePackageDatabase> logger)
+            ILogger<TablePackageDatabase> logger,
+            IOptions<AzureTableOptions> options)
         {
             _operationBuilder = operationBuilder ?? throw new ArgumentNullException(nameof(operationBuilder));
-            _table = client?.GetTableReference(TableName) ?? throw new ArgumentNullException(nameof(client));
+            _tableName = options.Value.TableName;
+            _table = client?.GetTableReference(_tableName) ?? throw new ArgumentNullException(nameof(client));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 

--- a/src/BaGet.Azure/Table/TableSearchService.cs
+++ b/src/BaGet.Azure/Table/TableSearchService.cs
@@ -6,21 +6,23 @@ using System.Threading.Tasks;
 using BaGet.Core;
 using BaGet.Protocol.Models;
 using Microsoft.Azure.Cosmos.Table;
+using Microsoft.Extensions.Options;
 
 namespace BaGet.Azure
 {
     public class TableSearchService : ISearchService
     {
-        private const string TableName = "Packages";
-
+        private readonly string _tableName;
         private readonly CloudTable _table;
         private readonly ISearchResponseBuilder _responseBuilder;
 
         public TableSearchService(
             CloudTableClient client,
-            ISearchResponseBuilder responseBuilder)
+            ISearchResponseBuilder responseBuilder,
+            IOptions<AzureTableOptions> options)
         {
-            _table = client?.GetTableReference(TableName) ?? throw new ArgumentNullException(nameof(client));
+            _tableName = options.Value.TableName;
+            _table = client?.GetTableReference(_tableName) ?? throw new ArgumentNullException(nameof(client));
             _responseBuilder = responseBuilder ?? throw new ArgumentNullException(nameof(responseBuilder));
         }
 


### PR DESCRIPTION
This is a small change to derive the Azure Tables table name from `AzureTableOptions` rather than the hardcoded "Packages" name.

- Similar to the option to set the Azure Blob container name, the table name must conform to Azure Table name rules and the table must already exist.

- A future enhancement would be to use the options builder pattern and use validation to ensure the options values follow the container and table name rules.
