### PR TITLE
#727: Normalize readme entry path prior to extraction

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,7 +29,7 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
-            return await package.GetStreamAsync(readmePath, cancellationToken);
+            return await package.GetStreamAsync(PathUtility.StripLeadingDirectorySeparators(readmePath), cancellationToken);
         }
 
         public async static Task<Stream> GetIconAsync(


### PR DESCRIPTION
Readme node path is now linux ready.

 * Used PathUtility to prepare the path to a readme to be linux compatible 

Fixing issue: https://github.com/loic-sharma/BaGet/issues/727
