### PR TITLE
Fixed broken links in features section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,11 @@ For more information, please refer to [our documentation](https://loic-sharma.gi
 ## Features
 
 * Cross-platform
-* [Dockerized](https://loic-sharma.github.io/BaGet/#running-baget-on-docker)
-* [Cloud ready](https://loic-sharma.github.io/BaGet/cloud/azure/)
-* [Supports read-through caching](https://loic-sharma.github.io/BaGet/configuration/#enabling-read-through-caching)
-* Can index the entirety of nuget.org. See [this documentation](https://loic-sharma.github.io/BaGet/import/nugetorg/#mirroring)
-* Coming soon: Supports [private feeds](https://loic-sharma.github.io/BaGet/private-feeds/)
+* [Dockerized](https://loic-sharma.github.io/BaGet/installation/docker/)
+* [Cloud ready](https://loic-sharma.github.io/BaGet/installation/azure/)
+* [Supports read-through caching](https://loic-sharma.github.io/BaGet/configuration/#enable-read-through-caching)
+* Can index the entirety of nuget.org. See [this documentation](https://loic-sharma.github.io/BaGet/configuration/#enable-read-through-caching)
+* Coming soon: Supports [private feeds](https://loic-sharma.github.io/BaGet/configuration/#private-feeds)
 * And more!
 
 Stay tuned, more features are planned!


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

The links in the Features section of readme.md were broken.

Addresses https://github.com/loic-sharma/BaGet/issues/123
