### PR TITLE
Fix unclosed XML tag in PackageReference syntax

### DIFF
--- a/src/BaGet.Web/Pages/Package.cshtml
+++ b/src/BaGet.Web/Pages/Package.cshtml
@@ -305,7 +305,7 @@ else
                 {
                     name: "PackageReference",
                     prefix: "",
-                    content: ["<PackageReference Include=\"@Model.Package.Id\" Version=\"@Model.Package.NormalizedVersionString\">"]
+                    content: ["<PackageReference Include=\"@Model.Package.Id\" Version=\"@Model.Package.NormalizedVersionString\" />"]
                 },
                 {
                     name: "Paket CLI",


### PR DESCRIPTION
When you want to add a dependency from a BaGet server, you have the option to copy the `<PackageReference>` element that would go in the .csproj file. However the element you copy is malformed: it is unclosed. E.g., here's what you copy:

```
<PackageReference Include="Mypackage" Version="1.2.3">
```

What you should copy is this:

```
<PackageReference Include="Mypackage" Version="1.2.3"/>
```

Notice the `/>` at the end. The backslash was missing. This PR fixes that.
