### PR TITLE
Add v3-flatcontainer as in api.nuget.com

### DIFF
--- a/src/BaGet.Web/BaGetEndpointBuilder.cs
+++ b/src/BaGet.Web/BaGetEndpointBuilder.cs
@@ -17,6 +17,8 @@ namespace BaGet
             MapSearchRoutes(endpoints);
             MapPackageMetadataRoutes(endpoints);
             MapPackageContentRoutes(endpoints);
+            MapPackageVersionRoutes(endpoints);
+
         }
 
         public void MapServiceIndexRoutes(IEndpointRouteBuilder endpoints)
@@ -125,6 +127,14 @@ namespace BaGet
                 name: Routes.PackageDownloadIconRouteName,
                 pattern: "v3/package/{id}/{version}/icon",
                 defaults: new { controller = "PackageContent", action = "DownloadIcon" });
+        }
+
+        public void MapPackageVersionRoutes(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapControllerRoute(
+                name: Routes.PackageVersionsRouteName,
+                pattern: "v3-flatcontainer/{packageId}/index.json",
+                defaults: new { controller = "VersionsController", action = "GetVersionsForPackage" });
         }
     }
 }

--- a/src/BaGet.Web/Controllers/VersionsController.cs
+++ b/src/BaGet.Web/Controllers/VersionsController.cs
@@ -1,0 +1,34 @@
+using BaGet.Core;
+using BaGet.Web.Dtos;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+
+namespace BaGet.Web.Controllers
+{
+    [Route("v3-flatcontainer/{packageId}/index.json")]
+    [ApiController]
+    public class VersionsController : ControllerBase
+    {
+        private readonly IPackageDatabase _packageDatabase;
+        public VersionsController(IPackageDatabase packageDatabase)
+        {
+            _packageDatabase = packageDatabase;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<string>>> GetVersionsForPackage(string packageId)
+        {
+            Console.WriteLine($"--> Getting versions for package {packageId} from Automaise nuget");
+            var exists = await _packageDatabase.ExistsAsync(packageId, new System.Threading.CancellationToken());
+            if (!exists)
+                return NotFound();
+            var retVersions = await _packageDatabase.FindAsync(packageId, true, new System.Threading.CancellationToken());
+            var versionDto = new VersionDto();
+            versionDto.versions = retVersions.Select(x => x.Version.ToString()).ToList();
+            return Ok(versionDto);
+        }
+    }
+}

--- a/src/BaGet.Web/Dtos/VersionsDto.cs
+++ b/src/BaGet.Web/Dtos/VersionsDto.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace BaGet.Web.Dtos
+{
+    public class VersionDto
+    {
+        public List<string> versions { get; set; } = new List<string>();
+    }
+}


### PR DESCRIPTION
In order to have a similar endpoint to get all versions for a specific package as we have in nuget.org.
Example : https://api.nuget.org/v3-flatcontainer/Microsoft.NETCore.Platforms/index.json

 * Added a VersionsController;
 * Added  logic to gather the info for versions in VersionsController
 * Added a similar route as in nuget.org in BaGetEndpointBuilder (it looks like https://localhost/v3-flatcontainer/{package}/index.json
