### PR TITLE
Add AllowPreReleasePackageOverwrites option

### DIFF
--- a/src/BaGet.Core/Configuration/BaGetOptions.cs
+++ b/src/BaGet.Core/Configuration/BaGetOptions.cs
@@ -33,6 +33,12 @@ namespace BaGet.Core
         public bool AllowPackageOverwrites { get; set; } = false;
 
         /// <summary>
+        /// If enabled, pushing a pre released package that already exists will replace the
+        /// existing package.
+        /// </summary>
+        public bool AllowPreReleasePackageOverwrites { get; set; } = false;
+
+        /// <summary>
         /// If true, disables package pushing, deleting, and re-listing.
         /// </summary>
         public bool IsReadOnlyMode { get; set; } = false;

--- a/src/BaGet.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGet.Core/Indexing/PackageIndexingService.cs
@@ -82,7 +82,14 @@ namespace BaGet.Core
             // The package is well-formed. Ensure this is a new package.
             if (await _packages.ExistsAsync(package.Id, package.Version, cancellationToken))
             {
-                if (!_options.Value.AllowPackageOverwrites)
+                if (package.IsPrerelease)
+                {
+                    if (!_options.Value.AllowPreReleasePackageOverwrites)
+                    {
+                        return PackageIndexingResult.PackageAlreadyExists;
+                    }
+                }
+                else if (!_options.Value.AllowPackageOverwrites)
                 {
                     return PackageIndexingResult.PackageAlreadyExists;
                 }

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -2,6 +2,7 @@
   "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
+  "AllowPreReleasePackageOverwrites": false,
 
   "Database": {
     "Type": "Sqlite",


### PR DESCRIPTION
Add new option AllowPreReleasePackageOverwrites to control explicitly if a "pre-release" package may be overwritten or not.

See
[Addresses https://github.com/loic-sharma/BaGet/issues/123](https://github.com/loic-sharma/BaGet/issues/764)
