### PR TITLE
docker: run app executable instead of dotnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ FROM base AS final
 LABEL org.opencontainers.image.source="https://github.com/loic-sharma/BaGet"
 WORKDIR /app
 COPY --from=publish /app .
-ENTRYPOINT ["dotnet", "BaGet.dll"]
+ENTRYPOINT ["./BaGet"]


### PR DESCRIPTION
 * Changes the entrypoint of the docker image to the BaGet executable produced by `dotnet publish`.
 * I am not aware of any downsides to this.
 * I am aware of one upside, which is that the process is easier to identify in many situations, as processes are usually identified by the filename of their executable. So if you see "dotnet dumped core" in your log files, this would become "BaGet dumped core".