### PR TITLE
Fix unit tests

### DIFF
--- a/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
+++ b/tests/BaGet.Core.Tests/Metadata/RegistrationBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -60,6 +61,7 @@ namespace BaGet.Core.Tests.Metadata
                 PackageTypes = new List<PackageType> { new PackageType { Name = "test" } },
                 Dependencies = new List<PackageDependency> { },
                 Version = new NuGetVersion(version),
+                Published = new DateTime(2003, 1, 4, 15, 9, 26, 535),
             };
         }
     }

--- a/tests/BaGet.Tests/HostIntegrationTests.cs
+++ b/tests/BaGet.Tests/HostIntegrationTests.cs
@@ -69,7 +69,7 @@ namespace BaGet.Tests
                 })
                 .Build();
 
-            return host.Services;
+            return host.Services.CreateScope().ServiceProvider;
         }
     }
 }


### PR DESCRIPTION
* Fix `TheRegistrationIndexResponseIsSortedByVersion` test

The implicit conversion from the default DateTime to DateTimeOffset was throwing `System.ArgumentOutOfRangeException`
> The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')

* Fix HostIntegrationTests

Resolving services from the root provider was throwing `System.InvalidOperationException`
> Cannot resolve scoped service 'BaGet.Core.IContext' from root provider.