### PR TITLE
Fix issue with packages containing backslash in readmePath or iconPath under linux

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,7 +29,10 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
-            return await package.GetStreamAsync(readmePath, cancellationToken);
+            return await package.GetStreamAsync(
+                PathUtility.StripLeadingDirectorySeparators(
+                    PathUtility.GetPathWithBackSlashes(readmePath)), 
+                cancellationToken);
         }
 
         public async static Task<Stream> GetIconAsync(
@@ -37,7 +40,8 @@ namespace BaGet.Core
             CancellationToken cancellationToken)
         {
             return await package.GetStreamAsync(
-                PathUtility.StripLeadingDirectorySeparators(package.NuspecReader.GetIcon()),
+                PathUtility.StripLeadingDirectorySeparators(
+                    PathUtility.GetPathWithBackSlashes(package.NuspecReader.GetIcon())), 
                 cancellationToken);
         }
 


### PR DESCRIPTION
always use forward slashes as this works on windows and linux

Summary of the changes (in less than 80 chars)

 * Always use forward slashes in readme and icon path
 * Remove leading slashes in readme path as already done for icon path

Addresses https://github.com/loic-sharma/BaGet/issues/513
