### PR TITLE
Allow FormOptions to be configured in appsettings.json

### DIFF
--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -37,6 +37,7 @@ namespace BaGet
             services.AddTransient<IConfigureOptions<IISServerOptions>, ConfigureBaGetOptions>();
             services.AddTransient<IValidateOptions<BaGetOptions>, ConfigureBaGetOptions>();
 
+            services.AddBaGetOptions<FormOptions>(nameof(FormOptions));
             services.AddBaGetOptions<IISServerOptions>(nameof(IISServerOptions));
             services.AddBaGetWebApplication(ConfigureBaGetApplication);
 


### PR DESCRIPTION
As the FormOptions allow to configure e.g. MultipartBodyLengthLimit, allowing larger packages will also need this options to be conifgurable using the appsettings.json, which will be enabled by the change:

```
  "FormOptions": {
    "MultipartBodyLengthLimit": 214748364700,
  },

  "IISServerOptions": {
    "MaxRequestBodySize": 26214400000,
  },
```