### PR TITLE
Fix: Error if README is in a subdirectory

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,6 +29,8 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
+            readmePath = PathUtility.StripLeadingDirectorySeparators(readmePath);
+
             return await package.GetStreamAsync(readmePath, cancellationToken);
         }
 


### PR DESCRIPTION
Error if README is in a subdirectory when pushing a package.

```
2023-09-11 10:58:04 fail: BaGet.Core.PackageIndexingService[0]
2023-09-11 10:58:04       Uploaded package is invalid
2023-09-11 10:58:04 System.IO.FileNotFoundException: docs\README.md
2023-09-11 10:58:04    at NuGet.Packaging.ZipArchiveExtensions.LookupEntry(ZipArchive zipArchive, String path)
2023-09-11 10:58:04    at NuGet.Packaging.ZipArchiveExtensions.OpenFile(ZipArchive zipArchive, String path)
2023-09-11 10:58:04    at NuGet.Packaging.PackageArchiveReader.GetStream(String path)
2023-09-11 10:58:04    at NuGet.Packaging.PackageReaderBase.GetStreamAsync(String path, CancellationToken cancellationToken)
2023-09-11 10:58:04    at BaGet.Core.PackageArchiveReaderExtensions.GetReadmeAsync(PackageArchiveReader package, CancellationToken cancellationToken) in /src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs:line 32
2023-09-11 10:58:04    at BaGet.Core.PackageIndexingService.IndexAsync(Stream packageStream, CancellationToken cancellationToken) in /src/BaGet.Core/Indexing/PackageIndexingService.cs:line 56
```

Example
- https://www.nuget.org/packages/MailKit/4.2.0
- https://www.nuget.org/packages/MimeKit/4.2.0
