### PR TITLE
Adds .NET 6.0, .NET 7.0, .NET 8.0, and .NET Framework 4.8.1 to TargetFrameworks

### DIFF
--- a/src/BaGet.Web/Pages/Index.cshtml
+++ b/src/BaGet.Web/Pages/Index.cshtml
@@ -189,6 +189,8 @@ else
         { "divider1", "-" },
         { "header1", ".NET" },
 
+        { "net7.0", ".NET 7.0" }
+        { "net6.0", ".NET 6.0" }
         { "net5.0", ".NET 5.0" },
 
         { "divider2", "-" },
@@ -217,6 +219,7 @@ else
         { "divider4", "-" },
         { "header4", ".NET Framework" },
 
+        { "net481", ".NET Framework 4.8.1" },
         { "net48", ".NET Framework 4.8" },
         { "net472", ".NET Framework 4.7.2" },
         { "net471", ".NET Framework 4.7.1" },

--- a/src/BaGet.Web/Pages/Index.cshtml
+++ b/src/BaGet.Web/Pages/Index.cshtml
@@ -189,6 +189,7 @@ else
         { "divider1", "-" },
         { "header1", ".NET" },
 
+        { "net8.0", ".NET 8.0" },
         { "net7.0", ".NET 7.0" },
         { "net6.0", ".NET 6.0" },
         { "net5.0", ".NET 5.0" },

--- a/src/BaGet.Web/Pages/Index.cshtml
+++ b/src/BaGet.Web/Pages/Index.cshtml
@@ -189,6 +189,8 @@ else
         { "divider1", "-" },
         { "header1", ".NET" },
 
+        { "net7.0", ".NET 7.0" },
+        { "net6.0", ".NET 6.0" },
         { "net5.0", ".NET 5.0" },
 
         { "divider2", "-" },
@@ -217,6 +219,7 @@ else
         { "divider4", "-" },
         { "header4", ".NET Framework" },
 
+        { "net481", ".NET Framework 4.8.1" },
         { "net48", ".NET Framework 4.8" },
         { "net472", ".NET Framework 4.7.2" },
         { "net471", ".NET Framework 4.7.1" },


### PR DESCRIPTION
Adds additional frameworks for searching

 * .NET 7.0 (`net7.0`)
 * .NET 6.0 (`net6.0`)
 * .NET Framework 4.8.1 (`net481`)

Addresses https://github.com/loic-sharma/BaGet/issues/750
